### PR TITLE
Add ATTRIBUTIONS.md with GitHub Docs attribution

### DIFF
--- a/ATTRIBUTIONS.md
+++ b/ATTRIBUTIONS.md
@@ -1,0 +1,6 @@
+# Attributions
+
+Some content in the *project documentation*—which defines the documentation framework used in this repository—is adapted from [GitHub Docs](https://docs.github.com) by GitHub, licensed under [Creative Commons Attribution 4.0 International (CC BY 4.0)](https://creativecommons.org/licenses/by/4.0/).
+Modifications include restructuring, rewritten examples, and additional commentary to align with our style guidelines. No endorsement by GitHub is implied.
+
+This attribution does **not** apply to the individual documentation of the projects hosted in this repository, which are original works by their respective teams.


### PR DESCRIPTION
We use GitHub Docs examples in many of our examples and templates.

We must properly attribute these projects in the `ATTRIBUTIONS.md` file and at the end of every file where we copy large blocks of text using:

> Adapted from GitHub Docs (CC BY 4.0)

`closes: #19`