### PR TITLE
(#141) Use the Logos Chat module API from an app

### DIFF
--- a/docs/apps/chat-demo/journeys/use-the-logos-chat-module-api-from-an-app.md
+++ b/docs/apps/chat-demo/journeys/use-the-logos-chat-module-api-from-an-app.md
@@ -1,4 +1,8 @@
-# Use a demo chat app in Logos Core to send and receive messages via Logos ChatSDK and Logos Messaging
+# Use the Logos Chat module API from an app
+
+> [!IMPORTANT]
+>
+> This page is not ready to follow as a guide. Expect missing sections, incomplete steps, and placeholders. Use it only to understand what we plan to document and what is still missing. We are actively working to complete and verify this content.
 
 Applies to:
 


### PR DESCRIPTION
This PR adds a Stub page for the journey "Use a demo chat app in Logos Core to send and receive messages" and links it to the Testnet v0.1 docs inventory. The page is intentionally incomplete waiting for:

- [ ] Doc Packet inputs or document draft

