### PR TITLE
(#145) External dev tests the Logos Messaging module via its API

### DIFF
--- a/docs/messaging/journeys/use-the-logos-delivery-module-api-from-an-app.md
+++ b/docs/messaging/journeys/use-the-logos-delivery-module-api-from-an-app.md
@@ -1,4 +1,8 @@
-# External dev tests the Logos Messaging module via its API
+# Use the Logos Delivery Module API from an app
+
+> [!IMPORTANT]
+>
+> This page is not ready to follow as a guide. Expect missing sections, incomplete steps, and placeholders. Use it only to understand what we plan to document and what is still missing. We are actively working to complete and verify this content.
 
 Applies to:
 
@@ -18,11 +22,11 @@ Tracking: GitHub issue [#145](https://github.com/logos-co/logos-docs/issues/145)
 
 ## Audience
 
-- developer
+- developers
 
 ## Known gaps
 
-- Doc Packet missing
+- Doc Packet missings
 - Logos testnet specifics missing: which network endpoints/bootstraps to use, whether RLN is required, and what "success" means for v0.1 beyond basic API calls.
 
 ## Prerequisites


### PR DESCRIPTION
This PR adds a Stub page for the journey "External dev tests the Logos Messaging module via its API" and links it to the Testnet v0.1 docs inventory. The page is intentionally incomplete waiting for:

- [ ] Doc Packet inputs or document draft
