### PR TITLE
(#159) Create and transfer custom tokens on the Logos Execution Zone

### DIFF
--- a/docs/apps/wallet/journeys/create-and-transfer-custom-tokens-on-the-logos-execution-zone.md
+++ b/docs/apps/wallet/journeys/create-and-transfer-custom-tokens-on-the-logos-execution-zone.md
@@ -14,6 +14,10 @@ slug: create-and-transfer-custom-tokens-on-the-logos-execution-zone
 
 #### Use the wallet CLI to create custom tokens and transfer them between public and private accounts.
 
+> [!IMPORTANT]
+>
+> This page is an early draft and may be incomplete or incorrect. Expect changes, missing prerequisites, and commands that might not work in your setup. We are actively working to complete and verify this content.
+
 > [!NOTE]
 >
 > - **Permissions**: No special permissions required.


### PR DESCRIPTION
This PR adds a Stub page for the journey "Create and transfer custom tokens in public and private states" and links it to the Testnet v0.1 docs inventory. The page is intentionally incomplete waiting for:

- [x] Doc Packet inputs or document draft
- [ ] Notion/repo -> journey mapping

