### PR TITLE
(#174) Build and run Logos App (alpha) to access Testnet v0.1 UIs

### DIFF
--- a/docs/core/journeys/build-and-run-logos-app-alpha-to-access-testnet-v0.1-uis.md
+++ b/docs/core/journeys/build-and-run-logos-app-alpha-to-access-testnet-v0.1-uis.md
@@ -1,5 +1,9 @@
 # Build and run Logos App (alpha) to access Testnet v0.1 UIs
 
+> [!IMPORTANT]
+>
+> This page is not ready to follow as a guide. Expect missing sections, incomplete steps, and placeholders. Use it only to understand what we plan to document and what is still missing. We are actively working to complete and verify this content.
+
 Applies to: https://github.com/logos-co/logos-app-poc@master
 Runtime target: Logos testnet v0.1 (Logos App runs locally, and provides alpha UIs for v0.1 modules/apps)  
 Last checked: 2026-02-13  


### PR DESCRIPTION
This PR adds a Stub page for the journey "Users interact with sample apps in public and private state" and links it to the Testnet v0.1 docs inventory. The page is intentionally incomplete waiting for:

- [ ] Doc Packet inputs or document draft


