### PR TITLE
Updates to initial CONTRIBUTING.md guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to Logos documentation
 
-Thanks for contributing to Logos documentation! This guide explains how to propose changes and submit contributions. Read the [Logos Code of Conduct](https://github.com/logos-co/roadmap/blob/v4/CODE_OF_CONDUCT.md) to keep this place approachable and respectable.
+Thanks for contributing to Logos documentation! This guide explains how to propose changes and submit contributions.
 
 > TL;DR: if you know how to create GitHub issues and pull requests, skip the [Contribute using a pull request](#contribute-using-a-pull-request) section.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,142 @@
-# Contributing
+# Contributing to Logos documentation
 
-## File names and location rules
+Thanks for contributing to Logos documentation! This guide explains how to propose changes and submit contributions. Read the [Logos Code of Conduct](https://github.com/logos-co/roadmap/blob/v4/CODE_OF_CONDUCT.md) to keep this place approachable and respectable.
+
+> TL;DR: if you know how to create GitHub issues and pull requests, skip the [Contribute using a pull request](#contribute-using-a-pull-request) section.
+
+## What to contribute
+
+- Bug fixes: Fix typos, broken links, formatting issues, or outdated information.
+- Updates: Update existing articles to reflect the latest information, features, or best practices.
+- New articles: Write new articles to cover missing topics or expand existing content.
+
+    > Refer to the [Logos technical documentation guide](./manual/README.md) for your writing workflow. Create new articles using [templates](./manual/2-populate-the-structure/templates/README.md). If you have doubts about how to write something, check the [writing rules](./manual/3-validate-the-design/writing-rules/README.md).
+
+## How to contribute
+
+You can contribute using GitHub issues or pull requests.
+
+Consider these guidelines when creating issues or pull requests:
+
+- In one issue or pull request, address only one document.
+- If your pull request is related to an existing issue, [link the pull request to the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-to-an-issue) on the GitHub website.
+- Mention the document title in the issue and pull request title. An issue and its corresponding pull request must have the same title.
+
+    | Usage   | Issue and pull request title                       |
+    |:--------|:---------------------------------------------------|
+    | Correct | Run a Logos base-layer node                             |
+    | Correct | Fix typo in Track transactions through an LSSA explorer |
+
+- Use the issue number and title as the branch name for the pull request. Separate words with dashes.
+
+    | Usage    | Branch name                                             |
+    |:---------|:--------------------------------------------------------|
+    | Correct  | `1234-run-a-logos-base-layer-node`                             |
+    | Correct  | `5678-fix-typo-in-track-transactions-through-an-lssa-explorer` |
+
+- Use the `documentation` label for all issues and pull requests.
+- Select `type` for issues.
+  - Bug: for reporting bugs or typos.
+  - Enhancement: for suggesting improvements or new features.
+  - Task: for new documents.
+- Include your issue in the [Logos docs](https://github.com/orgs/logos-co/projects/9) project board.
+
+## File name rules
+
+Your article's title determines the Markdown file name:
+
+- Use the article's title in all-lowercase letters for the Markdown file name.
+- Use a dash symbol ("-") to replace spaces.
+- Don't exclude articles, prepositions, or any other word in the Markdown file name.
+- If the name includes apostrophes, remove them from the Markdown file name.
+
+    | Article name                          | Markdown file name                        |
+    |:--------------------------------------|:------------------------------------------|
+    | Do's and don'ts of node security      | `dos-and-donts-of-node-security.md`       |
+    | FAQ: Build a dApp on Logos blockchain | `faq-build-a-dapp-on-logos-blockchain.md` |
+
+## Contribute using a pull request
+
+### 1. Fork and clone this repository
+
+To understand how a repository fork works, see [About forks](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/about-forks) in the GitHub documentation.
+
+1. Using the terminal, go to the directory where you want to clone the Logos documentation repository.
+1. Fork and clone the repository:
+
+    ```sh
+    gh repo fork 'logos-co/logos-docs' --remote --clone=true
+    ```
+
+### 2. Create a topic branch and make changes to your own branch
+
+1. Update your local `main` branch:
+
+    ```sh
+    git checkout main
+    git pull
+    ```
+
+1. Using the `main` branch, create a topic branch to include your changes:
+
+    ```sh
+    git checkout -b your-topic-branch-name main
+    ```
+
+1. Using the editor of your choice, write the required changes.
+
+### 3. Commit and push your work to your own fork
+
+1. Stage your changes:
+
+    ```sh
+    git add --all
+    ```
+
+1. Commit your changes with a description of what's included:
+
+    ```sh
+    git commit -m "description of your changes"
+    ```
+
+1. Set the `upstream` to push your changes:
+
+    ```sh
+    git push --set-upstream origin your-topic-branch-name
+    ```
+
+1. If you need to add more changes, you don't need to set the `upstream` branch again:
+
+    ```sh
+    git push
+    ```
+
+### 4. Submit your pull request
+
+1. Create a pull request with your proposed changes:
+
+    ```sh
+    gh pr create --base main --title "your pull request title"
+    ```
+
+1. When asked for the **Body**, type `e` to launch the default terminal editor. Include a description of the proposed changes:
+
+    `? Body [(e) to launch nano, enter to skip]`
+
+    > You can also skip this step and add the pull request description using the GitHub webpage.
+
+1. In the **What's next** question, select `Submit` to submit your pull request, or `Continue in browser` to finish your pull request in the GitHub website:
+
+    ```bash
+    ? What's next?  [Use arrows to move, type to filter]
+    > **Submit**
+      Continue in browser
+      Add metadata
+      Cancel
+    ```
+
+### 5. Review and merge
+
+- We may ask for changes to be made before a PR can be merged, either using [suggested changes](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/incorporating-feedback-in-your-pull-request) or pull request comments.
+- As you update your PR and apply changes, mark each conversation as [resolved](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/commenting-on-a-pull-request#resolving-conversations).
+- Merge your pull request using **Squash and merge** on your pull request page.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,142 +1,250 @@
 # Contributing to Logos documentation
 
-Thanks for contributing to Logos documentation! This guide explains how to propose changes and submit contributions.
+This guide explains how to contribute to the Logos documentation project hosted at [`logos-docs`](https://github.com/logos-co/logos-docs/). It covers the contribution process for anyone - whether you are part of the Logos organization or an external contributor.
 
-> TL;DR: if you know how to create GitHub issues and pull requests, skip the [Contribute using a pull request](#contribute-using-a-pull-request) section.
+## Overview
 
-## What to contribute
+Logos documentation lives in the [`docs/`](./docs/) folder of this repository. Every document follows one of five [canonical templates](./resources/templates/README.md) loosely based on [DITA standards](https://docs.oasis-open.org/dita/dita/v1.3/os/part2-tech-content/archSpec/technicalContent/dita-technicalContent-InformationTypes.html), uses a shared set of [writing rules](./resources/writing-rules/README.md), and goes through a review process before publication.
 
-- Bug fixes: Fix typos, broken links, formatting issues, or outdated information.
-- Updates: Update existing articles to reflect the latest information, features, or best practices.
-- New articles: Write new articles to cover missing topics or expand existing content.
+The Docs team (Technical Writers) owns the documentation workflow. R&D teams provide technical input and review. The Red Team validates that published documentation works end-to-end in a testing environment.
 
-    > Refer to the [Logos technical documentation guide](./manual/README.md) for your writing workflow. Create new articles using [templates](./manual/2-populate-the-structure/templates/README.md). If you have doubts about how to write something, check the [writing rules](./manual/3-validate-the-design/writing-rules/README.md).
+## Document types
+
+Every document in this project uses one of these types. Choosing the right type is mandatory before writing.
+
+<!-- TODO: Add final templates links once all resources are committed. -->
+
+| Type | Purpose | Use when... |
+|:---|:---|:---|
+| Quickstart | Get a user from zero to a working result fast. | The reader needs to try something for the first time with minimal setup. |
+| Procedure | Walk through a goal-oriented workflow step by step. | The reader needs to complete a specific task they already understand. |
+| Concept | Explain what something is and how it works. | The reader needs to understand a system, component, or idea before acting. |
+| Reference | Provide structured lookup information. | The reader needs to check a flag, parameter, API field, or config option. |
+| Troubleshooting | Diagnose and fix problems. | The reader hit an error and needs symptom-to-fix guidance. |
+
+If you are unsure which type fits, open an issue describing what you want to document and the Docs team will help you choose.
+
+## Resources
+
+| Resource | Location | Purpose |
+|:---|:---|:---|
+| Canonical templates | [`resources/templates/`](./resources/templates/README.md) | Markdown and JSON templates for each document type. Non-negotiable structure. |
+| Writing rules | [`resources/writing-rules/`](./resources/writing-rules/README.md) | Style guide covering voice, formatting, code blocks, callouts, and terminology. |
+| Doc packet template | [`resources/templates/doc-packet.md`](./resources/templates/doc-packet.md) | Template R&D teams use to provide technical input for a new document. |
+| Project board | [Logos Docs project board](https://github.com/orgs/logos-co/projects/9) | Tracks every document from intake to publication. Read access is public. |
+| Labels reference | [Repository labels](https://github.com/logos-co/logos-docs/labels) | Label taxonomy used on issues and PRs. |
 
 ## How to contribute
 
-You can contribute using GitHub issues or pull requests.
+### Report a problem or request a new document
 
-Consider these guidelines when creating issues or pull requests:
+If you found an error in an existing document, want to request a new document, or have a suggestion, [open an issue](https://github.com/logos-co/logos-docs/issues/new/choose).
 
-- In one issue or pull request, address only one document.
-- If your pull request is related to an existing issue, [link the pull request to the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-to-an-issue) on the GitHub website.
-- Mention the document title in the issue and pull request title. An issue and its corresponding pull request must have the same title.
+Describe what you need clearly. Include:
 
-    | Usage   | Issue and pull request title                       |
-    |:--------|:---------------------------------------------------|
-    | Correct | Run a Logos base-layer node                             |
-    | Correct | Fix typo in Track transactions through an LSSA explorer |
+- The document path or URL (if reporting a problem with an existing doc).
+- What is wrong or missing.
+- For new document requests: the user journey or task you want documented, and why it matters.
 
-- Use the issue number and title as the branch name for the pull request. Separate words with dashes.
+The Docs team triages issues and decides priority.
 
-    | Usage    | Branch name                                             |
-    |:---------|:--------------------------------------------------------|
-    | Correct  | `1234-run-a-logos-base-layer-node`                             |
-    | Correct  | `5678-fix-typo-in-track-transactions-through-an-lssa-explorer` |
+### Fix or improve an existing document
 
-- Use the `documentation` label for all issues and pull requests.
-- Select `type` for issues.
-  - Bug: for reporting bugs or typos.
-  - Enhancement: for suggesting improvements or new features.
-  - Task: for new documents.
-- Include your issue in the [Logos docs](https://github.com/orgs/logos-co/projects/9) project board.
+If you want to fix a typo, clarify a step, update a command, or make any other improvement to an existing document:
 
-## File name rules
+1. Fork the repository.
+1. Create a branch with a descriptive name (for example, `fix/quickstart-node-typo`).
+1. Make your changes. Follow the [writing rules](./resources/writing-rules/README.md) and preserve the existing template structure. Do not reorganize sections or change the document type.
+1. Open a pull request against `main`. In the PR description, explain what you changed and why.
+1. The Docs team reviews your PR. For technical changes (commands, config values, expected outputs), an R&D SME may also review.
 
-Your article's title determines the Markdown file name:
+Keep PRs small and focused. One fix per PR is easier to review than a large batch of unrelated changes.
 
-- Use the article's title in all-lowercase letters for the Markdown file name.
-- Use a dash symbol ("-") to replace spaces.
-- Don't exclude articles, prepositions, or any other word in the Markdown file name.
-- If the name includes apostrophes, remove them from the Markdown file name.
+### Write a new document (core contributors)
 
-    | Article name                          | Markdown file name                        |
-    |:--------------------------------------|:------------------------------------------|
-    | Do's and don'ts of node security      | `dos-and-donts-of-node-security.md`       |
-    | FAQ: Build a dApp on Logos blockchain | `faq-build-a-dapp-on-logos-blockchain.md` |
+This section applies to Logos core contributors: R&D engineers, Docs team members, and Red Team members who are part of the full documentation workflow.
 
-## Contribute using a pull request
+Writing a new document follows a phased process tracked on the [project board](https://github.com/orgs/logos-co/projects/9). Each phase has a clear owner and a definition of done.
 
-### 1. Fork and clone this repository
+---
 
-To understand how a repository fork works, see [About forks](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/about-forks) in the GitHub documentation.
+## Workflow for core contributors
 
-1. Using the terminal, go to the directory where you want to clone the Logos documentation repository.
-1. Fork and clone the repository:
+The documentation process starts with R&D. The SME responsible for a feature or workflow is the one who opens the issue and provides the [doc packet](./resources/templates/doc-packet.md). The Docs team then takes that input and turns it into structured, publishable documentation.
 
-    ```sh
-    gh repo fork 'logos-co/logos-docs' --remote --clone=true
-    ```
+### Board columns
 
-### 2. Create a topic branch and make changes to your own branch
+The project board uses six columns. Each column represents a workflow stage and makes ownership explicit: anyone looking at the board can immediately see whose turn it is to act.
 
-1. Update your local `main` branch:
+| Column | Owner | What happens here | How items enter | How items exit |
+|:---|:---|:---|:---|:---|
+| Backlog | - | Journey is identified but not yet prioritized. | Issue is created. | Docs or Red Team prioritizes and assigns an R&D SME. |
+| Needs input (R&D) | R&D SME | R&D provides the doc packet or a draft in the issue. | Issue is assigned to an SME. | SME posts the doc packet, or 5 business days pass (see time-box rules). |
+| Drafting (Docs) | Docs | Docs writes the document in a PR linked to the issue. | Doc packet received, or input deadline passed. | Draft is ready for review. Review requested on the PR. |
+| In review (R&D + Red Team) | R&D SME + Red Team | SME reviews for technical correctness. Red Team tests end-to-end. Docs incorporates feedback. | PR is marked ready for review. | SME approves and Red Team report passes, or 5 business days pass (see time-box rules). |
+| Final edit (Docs) | Docs | Docs does the editorial pass (structure, grammar, linters) and merges. | Reviews complete or review deadline passed. | PR merged. |
+| Published | - | Document is live on GitHub. | PR is merged. | - |
 
-    ```sh
-    git checkout main
-    git pull
-    ```
+### Labels
 
-1. Using the `main` branch, create a topic branch to include your changes:
+Labels are organized into four groups. Every issue gets exactly one label from each applicable group.
 
-    ```sh
-    git checkout -b your-topic-branch-name main
-    ```
+**Area (required, one per issue).** Maps to the R&D team responsible for the subject matter.
 
-1. Using the editor of your choice, write the required changes.
+- `area:apps`
+- `area:blockchain-l1`
+- `area:connect`
+- `area:core`
+- `area:lssa-l2`
+- `area:messaging`
+- `area:storage`
 
-### 3. Commit and push your work to your own fork
+**Quality (required, one per issue).** Tracks the current quality level of the document. Updated as the document progresses.
 
-1. Stage your changes:
+| Label | Meaning |
+|:---|:---|
+| `quality:stub` | Placeholder page. Title, status, and known gaps only. Not runnable. |
+| `quality:unverified` | Structured draft with steps. Not confirmed by an SME. |
+| `quality:sme-verified` | SME confirmed technical correctness for a specific repo version. |
+| `quality:verified` | SME confirmed and Red Team tested end-to-end. |
 
-    ```sh
-    git add --all
-    ```
+**Type (required, one per issue).**
 
-1. Commit your changes with a description of what's included:
+| Label | Meaning |
+|:---|:---|
+| `type:journey` | A user journey document (the primary deliverable). |
+| `type:chore` | Repo maintenance, template updates, tooling work. |
+| `type:bug` | Factual error or broken instructions in a published doc. |
 
-    ```sh
-    git commit -m "description of your changes"
-    ```
+**Blocked (optional).** Apply the `blocked` label when an item cannot progress. Write the reason as a comment on the issue. Remove the label when the blocker is resolved.
 
-1. Set the `upstream` to push your changes:
+**Release (one per milestone).** For example, `release:testnet-v0.1`, `release:testnet-v0.2`. Used to filter the GitHub project board by release.
 
-    ```sh
-    git push --set-upstream origin your-topic-branch-name
-    ```
+### Milestones
 
-1. If you need to add more changes, you don't need to set the `upstream` branch again:
+Each release has a corresponding GitHub milestone (e.g., "Testnet v0.2"). The milestone groups related issues and provides a progress bar. The milestone due date is the target date for R&D to provide all doc packets for that release.
 
-    ```sh
-    git push
-    ```
+Issues are added to the milestone when they are prioritized and moved out of Backlog.
 
-### 4. Submit your pull request
+### Phases in detail
 
-1. Create a pull request with your proposed changes:
+| Phase | Owner | Action | Board column | Quality on exit |
+|:---|:---|:---|:---|:---|
+| 1. Input | R&D SME | Open an issue with the doc packet. | Needs input (R&D) or Drafting (Docs) | - |
+| 2. Draft | Docs | Create PR, write the document from the doc packet. | Drafting (Docs) | Stub or Unverified |
+| 3. Review | R&D SME + Red Team | SME verifies technical accuracy; Red Team tests end-to-end. | In review (R&D + Red Team) | SME-verified |
+| 4. Publish | Docs | Final editorial pass, merge, and publish. | Final edit (Docs) → Published | Verified |
 
-    ```sh
-    gh pr create --base main --title "your pull request title"
-    ```
+```mermaid
+flowchart TD
+    A["Others open the issue"] -->|secondary path| B
+    C["R&D opens the issue</br>with doc packet"] -->|primary path| D
 
-1. When asked for the **Body**, type `e` to launch the default terminal editor. Include a description of the proposed changes:
+    subgraph phase1 ["Phase 1: Input"]
+        B["Backlog<br />(not yet assigned)"]
+        D["Needs input (R&D)<br />Owner: R&D SME"]
+    end
 
-    `? Body [(e) to launch nano, enter to skip]`
+    D --> E
+    D -. "no input" .-> T1["Publish as stub<br />(quality:stub)"]
+    T1 -.-> E
 
-    > You can also skip this step and add the pull request description using the GitHub webpage.
+    subgraph phase2 ["Phase 2: Draft"]
+        E["Drafting (Docs)<br />Owner: Docs team"]
+    end
 
-1. In the **What's next** question, select `Submit` to submit your pull request, or `Continue in browser` to finish your pull request in the GitHub website:
+    E --> F
 
-    ```bash
-    ? What's next?  [Use arrows to move, type to filter]
-    > **Submit**
-      Continue in browser
-      Add metadata
-      Cancel
-    ```
+    subgraph phase3 ["Phase 3: Review"]
+        F["In review<br />Owner: R&D + Red Team"]
+    end
 
-### 5. Review and merge
+    F --> G
+    F -. "no review" .-> T2["Publish as unverified<br />(quality:unverified)"]
+    T2 -.-> G
 
-- We may ask for changes to be made before a PR can be merged, either using [suggested changes](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/incorporating-feedback-in-your-pull-request) or pull request comments.
-- As you update your PR and apply changes, mark each conversation as [resolved](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/commenting-on-a-pull-request#resolving-conversations).
-- Merge your pull request using **Squash and merge** on your pull request page.
+    subgraph phase4 ["Phase 4: Publish"]
+        G["Final edit (Docs)<br />Owner: Docs team"]
+    end
+
+    G --> H["Published<br />(document live on GitHub)"]
+
+    classDef rd fill:#EEEDFE,stroke:#AFA9EC,color:#3C3489
+    classDef docs fill:#E1F5EE,stroke:#5DCAA5,color:#085041
+    classDef neutral fill:#F1EFE8,stroke:#B4B2A9,color:#444441
+    classDef deadline fill:#FAECE7,stroke:#F0997B,color:#712B13
+    classDef phaseStyle fill:#FAFAF8,stroke:#B4B2A9,stroke-dasharray:4 4,color:#5F5E5A
+
+    class A,B,H neutral
+    class C,D,F rd
+    class E,G docs
+    class T1,T2 deadline
+    class phase1,phase2,phase3,phase4 phaseStyle
+```
+
+#### Phase 1: Input
+
+**Owner:** R&D SME.
+
+**Primary path (pull model).** The R&D SME opens an issue in this repository when a feature, workflow, or journey needs documentation. The issue must include a completed [doc packet](./resources/templates/doc-packet.md) pasted into the issue body. The doc packet is mandatory. It provides the minimum technical input the Docs team needs to start a draft: the journey's purpose, the components involved, prerequisites, a runnable happy path, and a verification step.
+
+If the SME also has a draft, a recorded demo, a `README.md`, or any other supplementary material, they link it in the issue in addition to the doc packet.
+
+When the doc packet is complete, Docs assigns a writer and moves the issue directly to "Drafting (Docs)." When the doc packet is present but incomplete, the issue stays in "Needs input (R&D)" phase.
+
+> [!IMPORTANT]
+>
+> If the doc packet is not available, Docs publishes a stub: the template skeleton with the journey title, status, known gaps, and a note that technical details are pending. The stub is a published page that makes the gap visible. It is not a draft hidden in a branch.
+
+**Secondary path (Red Team, Docs, or external).** If someone other than R&D identifies a documentation need (Red Team finds a gap during testing, an external contributor requests a new doc, or Docs identifies an undocumented journey), they open an issue describing the need. The issue goes to Backlog. Docs or Red Team assigns an R&D SME, who then provides the doc packet.
+
+**Definition of done:** A complete doc packet is posted in the issue.
+
+#### Phase 2: Draft
+
+**Owner:** Docs team (the writer assigned to the PR).
+
+Docs creates a PR linked to the issue and writes the document using the appropriate [canonical template](./resources/templates/README.md). The draft must follow the template structure exactly. Information that is missing or unconfirmed is marked explicitly in the document (e.g., "Technical details pending" for reader-facing text, or tracked in the PR description for internal notes).
+
+**Definition of done:** The draft is complete enough for review. Review is requested on the PR. The issue moves to "In review."
+
+#### Phase 3: Review
+
+**Owner:** R&D SME + Red Team, in parallel.
+
+- **SME review:** The SME checks that commands, config values, expected outputs, and technical explanations are correct for the repo version specified in the doc packet. The SME reviews on the PR using GitHub's review tools (approve, request changes, or comment).
+- **Red Team review:** The Red Team runs the journey end-to-end in their testing environment and reports whether the instructions work as documented. Gaps or failures are reported as PR comments.
+- **Docs:** Incorporates feedback from both reviews.
+
+**Definition of done:** The SME approves and the Red Team report passes.
+
+#### Phase 4: Final edit
+
+**Owner:** Docs team.
+
+Docs performs a final editorial pass: checks structure against the template, applies the writing rules, runs any linters, and updates the `quality:*` label to reflect the final state.
+
+**Definition of done:** PR merged. Issue closed.
+
+### Quality levels
+
+Quality labels track the document's reliability, not its position in the workflow. A document can be published at any quality level. The quality level is visible to readers and sets expectations.
+
+| Quality level | What the reader can expect |
+|:---|:---|
+| Stub | The page exists to reserve the journey and show its status. Content is minimal or absent. Not runnable. |
+| Unverified | The document has structured content with steps, but no SME has confirmed correctness. Commands and outputs may be inaccurate. |
+| SME-verified | An R&D SME has confirmed that the technical content is correct for a specific repo version. |
+| Verified | An SME has confirmed correctness and the Red Team has tested the journey end-to-end. This is the highest quality bar. |
+
+---
+
+## Document structure rules
+
+All documents must follow these rules regardless of who writes them.
+
+1. **Use a canonical template.** Every document must use the Markdown template for its type. Templates are in [`resources/templates/`](./resources/templates/README.md). Do not invent your own structure.
+1. **Follow the writing rules.** The style guide in [`resources/writing-rules/`](./resources/writing-rules/README.md) defines voice, formatting, terminology, and code block conventions. Read it before writing.
+1. **One document, one type.** Do not mix types. If a quickstart needs a long conceptual explanation, write a separate concept document and link to it.
+1. **Mark unknowns explicitly.** If you do not have the information for a required section, do not skip it. Write a clear note for the reader (for example., "Technical details pending - contact the [team] for status"). Track the gap in the PR or issue.
+1. **Do not break existing structure.** When editing an existing document, preserve its template structure, section IDs, and numbering. Change only what you need to change.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,11 +91,11 @@ Labels are organized into four groups. Every issue gets exactly one label from e
 
 **Area (required, one per issue).** Maps to the R&D team responsible for the subject matter.
 
+- `area:anoncomms`
 - `area:apps`
-- `area:blockchain-l1`
-- `area:connect`
+- `area:blockchain`
 - `area:core`
-- `area:lssa-l2`
+- `area:lez`
 - `area:messaging`
 - `area:storage`
 


### PR DESCRIPTION
@cheny0 , I have created a new PR for the `CONTRIBUTING.md` content, using your branch as the base for comparison. This content does not update your content, but replaces it.

Why? The initial draft provided a solid starting point, but several decisions made after that draft change the workflow fundamentally enough that a revision on top would be harder to follow than a clean replacement. Here is what changed.

- The guide now clearly differentiates two audiences: external contributors (open issues, fix typos) and core contributors (full workflow with phases, labels, milestones).
- A clear description of the different phases in the documentation workflow, with roles, responsibilities, and definitions of "done" for each phase.
- The external contributors' section does not go into details. The guide focuses now on the Docs <--> R&D <--> Red Team workflow. Please save your content because we'll use that later when we detail things for external contributors. At this time, **we should focus on the internal workflow only**.
- Switched from push (Docs creates issues and chases R&D for input) to pull (R&D opens the issue with the doc packet, because they are the ones who know what their code does).
- The doc packet is now mandatory. Drafts, demos, or other materials go in addition to the doc packet, not as a replacement.
- Introducing milestones with one milestone per release to group related issues and set expectations for R&D input deadlines.

> [!IMPORTANT]
>
> There are other changes in the labels, project board, milestones, and, in general, to the way we work with project items. These changes affect as well other parts of the `CONTRIBUTING.md` guide.