### PR TITLE
Fix typos: remove duplicate 'the' and correct 'missings' to 'missing'

### DIFF
--- a/docs/apps/wallet/journeys/quickstart-for-the-logos-execution-zone-wallet.md
+++ b/docs/apps/wallet/journeys/quickstart-for-the-logos-execution-zone-wallet.md
@@ -265,7 +265,7 @@ In this task, wallet account and transfer commands interact with the authenticat
 
 ### Claim funds using the Piñata faucet
 
-"Piñata" is the name of the the LEZ-specific testnet faucet program that funds accounts with native tokens.
+"Piñata" is the name of the LEZ-specific testnet faucet program that funds accounts with native tokens.
 
 1. Fund the sender account via Piñata:
 

--- a/docs/messaging/journeys/use-the-logos-delivery-module-api-from-an-app.md
+++ b/docs/messaging/journeys/use-the-logos-delivery-module-api-from-an-app.md
@@ -26,7 +26,7 @@ Tracking: GitHub issue [#145](https://github.com/logos-co/logos-docs/issues/145)
 
 ## Known gaps
 
-- Doc Packet missings
+- Doc Packet missing
 - Logos testnet specifics missing: which network endpoints/bootstraps to use, whether RLN is required, and what "success" means for v0.1 beyond basic API calls.
 
 ## Prerequisites


### PR DESCRIPTION
## Summary
Fixed 2 typos in the documentation to improve readability and correctness.

## Changes
1. **Wallet Quickstart Guide** (`docs/apps/wallet/journeys/quickstart-for-the-logos-execution-zone-wallet.md`, line 268)
   - Fixed duplicate word: "the the" → "the"
   
2. **Messaging Guide** (`docs/messaging/journeys/use-the-logos-delivery-module-api-from-an-app.md`, line 29)
   - Fixed incorrect plural: "missings" → "missing"

## Testing
- Verified markdown renders correctly
- No functional changes, documentation only