### PR TITLE
docs(blockchain): fix circuits URL, document programmatic faucet, refresh quickstart example

### DIFF
--- a/docs/blockchain/quickstart-guide-for-the-logos-blockchain-node.md
+++ b/docs/blockchain/quickstart-guide-for-the-logos-blockchain-node.md
@@ -199,16 +199,6 @@ A faucet distributes free tokens on test networks to experiment without financia
 
     ![Image of the faucet UI after requesting funds with a public key](./quickstart-guide-for-the-logos-blockchain-node/image1.png)
 
-    > [!TIP]
-    >
-    > **Programmatic alternative.** The faucet UI POSTs to `https://testnet.blockchain.logos.co/faucet-backend/<your-chosen-key>`. You can call that endpoint directly from a script or headless host:
-    >
-    > ```sh
-    > curl -X POST "https://testnet.blockchain.logos.co/faucet-backend/<your-chosen-key>"
-    > ```
-    >
-    > The response includes the transaction hash; the explorer URL it returns currently uses the `devnet.blockchain.logos.co` subdomain (see issue #244 for the testnet/devnet branding split).
-
 1. Wait 1 to 2 minutes, then verify that your funds were received by querying the balance of your wallet. Replace `<your-chosen-key>` with the key you used in the previous step:
 
     ```sh

--- a/docs/blockchain/quickstart-guide-for-the-logos-blockchain-node.md
+++ b/docs/blockchain/quickstart-guide-for-the-logos-blockchain-node.md
@@ -42,7 +42,7 @@ The node requires zero-knowledge circuit files for cryptographic operations. Zer
 
     ```sh
     # download ZK circuits
-    wget https://github.com/logos-blockchain/logos-blockchain/releases/download/0.1.2/logos-blockchain-circuits-v0.4.1-linux-x86_64.tar.gz
+    wget https://github.com/logos-blockchain/logos-blockchain/releases/download/0.1.2/logos-blockchain-circuits-v0.4.2-linux-x86_64.tar.gz
 
     # download node binary
     wget https://github.com/logos-blockchain/logos-blockchain/releases/download/0.1.2/logos-blockchain-node-linux-x86_64-0.1.2.tar.gz
@@ -52,7 +52,7 @@ The node requires zero-knowledge circuit files for cryptographic operations. Zer
 
     ```sh
     # download ZK circuits
-    wget https://github.com/logos-blockchain/logos-blockchain/releases/download/0.1.2/logos-blockchain-circuits-v0.4.1-linux-aarch64.tar.gz
+    wget https://github.com/logos-blockchain/logos-blockchain/releases/download/0.1.2/logos-blockchain-circuits-v0.4.2-linux-aarch64.tar.gz
 
     # download node binary
     wget https://github.com/logos-blockchain/logos-blockchain/releases/download/0.1.2/logos-blockchain-node-linux-aarch64-0.1.2.tar.gz
@@ -93,8 +93,8 @@ Bootstrap nodes are the initial contact points for joining the network. Once you
 
     ```sh
     ./logos-blockchain-node init \
-        -p {peer1} \
-        -p {peer2}
+        -p <peer1> \
+        -p <peer2>
     ```
 
     The bootstrap peers used for this command can be found in the [Logos Blockchain Node release notes](https://github.com/logos-blockchain/logos-blockchain/releases/latest). For example, the 0.1.2 release uses:
@@ -138,6 +138,7 @@ Before requesting tokens, wait for your node to finish syncing. The node must be
     ```json
     {
       "lib": "3d0c...4e6d",
+      "lib_slot": 0,
       "tip": "f44d...e2f5",
       "slot": 70899,
       "height": 120,
@@ -197,6 +198,16 @@ A faucet distributes free tokens on test networks to experiment without financia
 1. Choose any of the keys in `known_keys` and navigate to the [public faucet site](https://testnet.blockchain.logos.co/web/faucet/). Enter your chosen key in **Destination Public Key (Hex)** and press **Request Funds**.
 
     ![Image of the faucet UI after requesting funds with a public key](./quickstart-guide-for-the-logos-blockchain-node/image1.png)
+
+    > [!TIP]
+    >
+    > **Programmatic alternative.** The faucet UI POSTs to `https://testnet.blockchain.logos.co/faucet-backend/<your-chosen-key>`. You can call that endpoint directly from a script or headless host:
+    >
+    > ```sh
+    > curl -X POST "https://testnet.blockchain.logos.co/faucet-backend/<your-chosen-key>"
+    > ```
+    >
+    > The response includes the transaction hash; the explorer URL it returns currently uses the `devnet.blockchain.logos.co` subdomain (see issue #244 for the testnet/devnet branding split).
 
 1. Wait 1 to 2 minutes, then verify that your funds were received by querying the balance of your wallet. Replace `<your-chosen-key>` with the key you used in the previous step:
 


### PR DESCRIPTION
## Summary
Four small, independent fixes to the Blockchain node quickstart, all surfaced by a copy-paste-the-doc dogfooding run on a Raspberry Pi 5.

## Findings addressed
- **F-1** — bump the example `wget` URLs from circuits `v0.4.1` to `v0.4.2`. The 0.1.2 release ships v0.4.2 on disk and the bundled `setup-logos-blockchain-circuits.sh` already targets v0.4.2; the v0.4.1 URLs return HTTP 404. Verified: `curl -sI .../v0.4.2-linux-aarch64.tar.gz` → 200.
- **F-20** — switch the bootstrap-peer placeholders from `{peer1}`/`{peer2}` to `<peer1>`/`<peer2>` to match the convention used in Step 4 (`<your-chosen-key>`). Curly-brace placeholders risk being copy-pasted literally.
- **F-11** — add the `lib_slot` field to the example `/cryptarchia/info` response. The 0.1.2 node returns `lib_slot` and readers comparing the doc to the live response see an unexplained extra field.
- **F-8** — add a "Programmatic alternative" callout under Step 4 documenting `POST /faucet-backend/<pk>`. The UI flow uses this endpoint internally; documenting it gives headless / CI / scripted users a path that doesn't require a browser.

## Verification
- `curl -sI` on both new circuits URLs returns 200 (x86_64 + aarch64).
- The example JSON response with `lib_slot` matches the actual response shape observed during the dogfooding run on a node at SHA `c72fda5`.
- The `POST /faucet-backend/<pk>` endpoint was extracted from the public faucet UI's page source.

## Notes
- Source: dogfooding run on commit `c72fda5707070bf96bb52efb9a8b077e8b8893af` (Raspberry Pi 5, linux/aarch64, 2026-05-08).
- Findings F-2 (faucet currently returning HTTP 502) and F-13 (testnet/devnet terminology drift) were filed as separate issues — see issue #244 (`logos-co/logos-docs`) and issue #2727 (`logos-blockchain/logos-blockchain`) — because they need infra/branding decisions, not a doc edit.
- Findings F-17, F-23, F-28, F-29 are intentionally not addressed in this PR series because they touch docs marked "Status: Stub" (per F-24); they are tracked in the local task report.
