### PR TITLE
docs(anoncomms): use HTTPS clone URL and correct nix invocation

### DIFF
--- a/docs/connect/anoncomms/journeys/discover-nodes-and-send-messages-via-the-anoncomms-mixnet-demo-app.md
+++ b/docs/connect/anoncomms/journeys/discover-nodes-and-send-messages-via-the-anoncomms-mixnet-demo-app.md
@@ -33,7 +33,7 @@
   1. Clone the chat-ui repo
 
      ```shell
-     git clone git@github.com:logos-co/logos-chat-ui.git
+     git clone https://github.com/logos-co/logos-chat-ui.git
      ```
 
   2. Change into the repo directory and check out the demo branch
@@ -43,22 +43,16 @@
      git checkout logos-testnet-demo
      ```
 
-  3. Build the standalone application. You should not see any errors in the console.
+  3. Run the standalone application. You should not see any errors in the console.
 
      ```shell
-     nix build '.#app'
+     nix run '.'
      ```
 
      If you don't have flakes enabled globally, add experimental flags:
 
      ```shell
-     nix build '.#app' --extra-experimental-features 'nix-command flakes'
-     ```
-
-  4. Run the application
-
-     ```shell
-     ./result/bin/logos-chat-ui-app
+     nix run '.' --extra-experimental-features 'nix-command flakes'
      ```
 
 - **Expected outputs:**


### PR DESCRIPTION
## Summary
Two fixes to the AnonComms mixnet demo journey, both surfaced by copy-paste-the-doc dogfooding on a Raspberry Pi 5.

## Findings addressed
- **F-10** — switch the chat-ui clone from `git clone git@github.com:logos-co/logos-chat-ui.git` (SSH) to the HTTPS form. A first-time external developer without a GitHub SSH key gets `Permission denied (publickey)`. All other clone examples in this repo use HTTPS; this one was the exception.
- **F-22** — replace `nix build '.#app'` with `nix run '.'`. The `logos-chat-ui` flake exposes `apps.<system>.default` (runnable via `nix run`) and devShells/checks/config — there is no `packages.<system>.app` output. The original `nix build '.#app'` command fails on every host with `error: flake '…' does not provide attribute 'packages.<arch>.app' … Did you mean apps?`. The same change is applied to the "If you don't have flakes enabled globally" variant on the line below.

## Verification
- HTTPS clone URL: `git clone https://github.com/logos-co/logos-chat-ui.git` was used in this run's container and worked without credentials.
- Flake outputs: `nix flake show .` against `logos-co/logos-chat-ui` confirms `apps.<system>.default` exists for `aarch64-linux`, `x86_64-linux`, `aarch64-darwin`, and `x86_64-darwin`; no `packages.<system>.app` exists for any of them.

## Notes
- The branch-checkout bug in step 2 (`git checkout logos-testnet-demo` against a branch that no longer exists) is a separate finding (F-9) and is filed as issue #243; that fix needs the correct branch / commit SHA to be confirmed by someone with current knowledge of the chat-ui demo state, so it isn't bundled here.
- Source: dogfooding run on commit `c72fda5707070bf96bb52efb9a8b077e8b8893af` (Raspberry Pi 5, linux/aarch64, 2026-05-08).
- Findings F-17, F-23, F-28, F-29 are intentionally not addressed in this PR series because they touch docs marked "Status: Stub" (per F-24).
