### PR TITLE
Install the Logos Basecamp app

### DIFF
--- a/docs/core/journeys/install-the-logos-basecamp-app.md
+++ b/docs/core/journeys/install-the-logos-basecamp-app.md
@@ -12,7 +12,7 @@ slug: install-the-logos-basecamp-app
 
 # Install the Logos Basecamp app
 
-#### Get Basecamp running on Linux or macOS so you can load Logos modules and apps.
+#### Get Logos Basecamp running on your desktop.
 
 > [!NOTE]
 >
@@ -25,8 +25,8 @@ You can install Logos Basecamp in two ways:
 
 | Method | When to use it | Tooling required |
 |:--|:--|:--|
-| Prebuilt release (AppImage or DMG) | End users and most developers | None |
-| Build from source with Nix | Contributors, custom builds, unsupported platforms | Nix with flakes enabled |
+| [Prebuilt release (AppImage or DMG)](#install-from-a-prebuilt-release) | End users | None |
+| [Build from source with Nix](#build-and-run-logos-basecamp-from-source) | Contributors, custom builds, unsupported platforms | Nix with flakes enabled |
 
 Before you start, make sure you have the following:
 
@@ -41,13 +41,11 @@ Before you start, make sure you have the following:
 
 ## Install from a prebuilt release
 
-Use this path if you are an end user. The release page ships a Linux AppImage and a macOS DMG.
-
 1. Go to the [latest release page](https://github.com/logos-co/logos-basecamp/releases/latest) and download the artifact for your OS:
     - Linux: the `AppImage` files
     - macOS: the `.dmg` files
 
-1. Depending on your OS, launch the app as follows:
+1. Depending on your OS, install and launch the app as follows:
 
 - On macOS, drag the `.dmg` file into `/Applications`. Then launch the app from `/Applications`.
 - On Linux, grant execute permission to the downloaded AppImage and launch it:
@@ -58,8 +56,6 @@ Use this path if you are an end user. The release page ships a Linux AppImage an
     ```
 
 ## Build and run Logos Basecamp from source
-
-Use this path if you are contributing to Logos Basecamp or need a build for an unsupported platform. Nix with flakes enabled is required.
 
 1. Clone the repository and enter it:
 

--- a/docs/core/journeys/install-the-logos-basecamp-app.md
+++ b/docs/core/journeys/install-the-logos-basecamp-app.md
@@ -1,0 +1,81 @@
+---
+title: Install the Logos Basecamp app
+doc_type: procedure
+product: core
+topics: core
+steps_layout: flat
+authors: iurimatias, cheny0
+owner: logos
+doc_version: 1
+slug: install-the-logos-basecamp-app
+---
+
+# Install the Logos Basecamp app
+
+#### Get Basecamp running on Linux or macOS so you can load Logos modules and apps.
+
+> [!NOTE]
+>
+> - **Permissions**: No special permissions required.
+> - **Product**: Logos Basecamp.
+
+Logos Basecamp is the desktop shell for the Logos platform. You can discover, install, and run Logos modules and apps using its graphical interface as an alternative to the command line.
+
+You can install Logos Basecamp in two ways:
+
+| Method | When to use it | Tooling required |
+|:--|:--|:--|
+| Prebuilt release (AppImage or DMG) | End users and most developers | None |
+| Build from source with Nix | Contributors, custom builds, unsupported platforms | Nix with flakes enabled |
+
+Before you start, make sure you have the following:
+
+- Internet access.
+- A supported OS: Linux x86_64 or aarch64 (tested on Ubuntu 22.04+), or macOS x86_64 or aarch64 (recent versions).
+- 4 GB RAM minimum (8 GB recommended) and ~2 GB free disk space.
+- For the source build only: [Nix](https://github.com/NixOS/nix-installer) installed with flakes enabled.
+
+> [!NOTE]
+>
+> Internet access is required to download the binary or clone the repository, but not to launch Logos Basecamp afterward. Logos Basecamp itself opens no inbound ports. 
+
+## Install from a prebuilt release
+
+Use this path if you are an end user. The release page ships a Linux AppImage and a macOS DMG.
+
+1. Go to the [latest release page](https://github.com/logos-co/logos-basecamp/releases/latest) and download the artifact for your OS:
+    - Linux: the `AppImage` files
+    - macOS: the `.dmg` files
+
+1. Depending on your OS, launch the app as follows:
+
+- On macOS, drag the `.dmg` file into `/Applications`. Then launch the app from `/Applications`.
+- On Linux, grant execute permission to the downloaded AppImage and launch it:
+
+    ```bash
+    chmod +x logos-basecamp-*.AppImage
+    ./logos-basecamp-x86_64.AppImage  # or logos-basecamp-aarch64.AppImage
+    ```
+
+## Build and run Logos Basecamp from source
+
+Use this path if you are contributing to Logos Basecamp or need a build for an unsupported platform. Nix with flakes enabled is required.
+
+1. Clone the repository and enter it:
+
+    ```bash
+    git clone https://github.com/logos-co/logos-basecamp.git
+    cd logos-basecamp
+    ```
+
+1. Build the app with the Nix flake:
+
+    ```bash
+    nix build '.#app'
+    ```
+
+1. Run the resulting binary:
+
+    ```bash
+    ./result/bin/logos-basecamp
+    ```

--- a/docs/core/journeys/install-the-logos-basecamp-app.md
+++ b/docs/core/journeys/install-the-logos-basecamp-app.md
@@ -28,6 +28,10 @@ You can install Logos Basecamp in two ways:
 | [Prebuilt release (AppImage or DMG)](#install-from-a-prebuilt-release) | End users | None |
 | [Build from source with Nix](#build-and-run-logos-basecamp-from-source) | Contributors, custom builds, unsupported platforms | Nix with flakes enabled |
 
+> [!NOTE]
+>
+> To enable flakes in nix, add `experimental-features = nix-command flakes` to `/etc/nix/config`.
+
 Before you start, make sure you have the following:
 
 - Internet access.
@@ -73,5 +77,13 @@ Before you start, make sure you have the following:
 1. Run the resulting binary:
 
     ```bash
-    ./result/bin/logos-basecamp
+    ./result/bin/LogosBasecamp
     ```
+
+## Troubleshooting the Basecamp app
+### I see an `libEGL.so.1 / libOpenGL.so.0 missing` error when trying to launch the AppImage on Linux?
+Try running the following command:
+
+```bash
+sudo apt-get install -y fuse libegl1 libopengl0
+```


### PR DESCRIPTION
The journey "Build and run Logos App (alpha) to access Testnet v0.1 UIs" is split into two documents. The other pr is: https://github.com/logos-co/logos-docs/pull/258