### PR TITLE
docs: populate PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+## Linked issue
+Closes #
+
+## Summary of changes
+<!-- What changes and why. Keep it short. -->
+
+## Target doc type
+<!-- Pick one per CONTRIBUTING.md. -->
+Quickstart / Procedure / Concept / Reference / Troubleshooting
+
+## Target quality level
+<!-- Pick one per the `quality:*` label taxonomy. -->
+stub / unverified / sme-verified / verified
+
+## Checklist
+- [ ] Lint passes (`make lint-md`, `make lint-prose`, `make lint-spell`)
+- [ ] Links checked (`make lint-links`)


### PR DESCRIPTION
## Summary

Populates the previously empty `.github/pull_request_template.md` with the minimal set of fields needed for a docs-first repo:

- Linked issue
- Summary of changes
- Target doc type (the five canonical types from `CONTRIBUTING.md`)
- Target quality level (mirrors the `quality:*` label taxonomy)
- Checklist for lint and link checks (uses the Makefile targets called out in `.github/copilot-instructions.md`)

17 lines, terse style to match other files under `.github/`.

## Test plan

- [ ] On opening a new PR, the template renders as the default description.
- [ ] Headings and checklist boxes appear correctly.
- [ ] Lint/link commands in the checklist match what `.github/copilot-instructions.md` describes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)