### PR TITLE
docs(reference): add naming migration reference page

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Please open an issue in this repository describing what you are trying to comple
 
 We are consolidating and updating previously fragmented materials into a single, coherent developer experience and source of truth, featuring consistent navigation and terminology. This process is ongoing, and we appreciate your patience as we work to provide comprehensive and up-to-date documentation.
 
-We are also unifying public naming in our documentation to reflect Logos as a single technical stack: Nomos → Logos Blockchain, Codex → Logos Storage, and Waku → Logos Messaging. This consolidation makes the architecture easier to navigate by aligning documentation, examples, and terminology under one scheme. [Legacy names may still appear in repositories and specifications](/docs/reference/naming-migration.md), but going forward the Logos-first names will be used across our docs.
+We are also unifying public naming in our documentation to reflect Logos as a single technical stack: Nomos → [Logos Blockchain](https://github.com/logos-blockchain), Codex → [Logos Storage](https://github.com/logos-storage), and Waku → [Logos Messaging](https://github.com/logos-messaging). This consolidation makes the architecture easier to navigate by aligning documentation, examples, and terminology under one scheme. Legacy names may still appear in repositories and specifications, but going forward the Logos-first names will be used across our docs.
 
 Our aim is to provide a predictable onboarding path for operators and developers, where they can find what they need and trust what they read.
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Please open an issue in this repository describing what you are trying to comple
 
 We are consolidating and updating previously fragmented materials into a single, coherent developer experience and source of truth, featuring consistent navigation and terminology. This process is ongoing, and we appreciate your patience as we work to provide comprehensive and up-to-date documentation.
 
-We are also unifying public naming in our documentation to reflect Logos as a single technical stack: Nomos → Logos Blockchain, Codex → Logos Storage, and Waku → Logos Messaging. This consolidation makes the architecture easier to navigate by aligning documentation, examples, and terminology under one scheme. Legacy names may still appear in repositories and specifications, but going forward the Logos-first names will be used across our docs.
+We are also unifying public naming in our documentation to reflect Logos as a single technical stack: Nomos → Logos Blockchain, Codex → Logos Storage, and Waku → Logos Messaging. This consolidation makes the architecture easier to navigate by aligning documentation, examples, and terminology under one scheme. [Legacy names may still appear in repositories and specifications](/docs/reference/naming-migration.md), but going forward the Logos-first names will be used across our docs.
 
 Our aim is to provide a predictable onboarding path for operators and developers, where they can find what they need and trust what they read.
 

--- a/docs/reference/naming-migration.md
+++ b/docs/reference/naming-migration.md
@@ -1,0 +1,9 @@
+# Naming migration reference
+
+Logos consolidates previously separate projects under a single naming scheme. Legacy names may still appear in repositories and specifications. This page maps each legacy name to its current Logos-first name.
+
+| Legacy name | Current name | Repo / org |
+| ----------- | ------------ | ---------- |
+| Nomos | Logos Blockchain | https://github.com/logos-blockchain |
+| Codex | Logos Storage | https://github.com/logos-storage |
+| Waku | Logos Messaging | https://github.com/logos-messaging |

--- a/docs/reference/naming-migration.md
+++ b/docs/reference/naming-migration.md
@@ -1,9 +1,0 @@
-# Naming migration reference
-
-Logos consolidates previously separate projects under a single naming scheme. Legacy names may still appear in repositories and specifications. This page maps each legacy name to its current Logos-first name.
-
-| Legacy name | Current name | Repo / org |
-| ----------- | ------------ | ---------- |
-| Nomos | Logos Blockchain | https://github.com/logos-blockchain |
-| Codex | Logos Storage | https://github.com/logos-storage |
-| Waku | Logos Messaging | https://github.com/logos-messaging |


### PR DESCRIPTION
## Summary
- Add `docs/reference/naming-migration.md` mapping legacy names (Nomos, Codex, Waku) to current Logos-first names (Logos Blockchain, Logos Storage, Logos Messaging), with their public repo/org URLs.
- Link the README sentence that mentions legacy names appearing in repositories and specifications to the new reference page so the claim is backed by a concrete lookup.

## Notes
- Codex / Logos Storage org is at https://github.com/logos-storage (verified via the GitHub API; org name "Logos Storage", description "Privacy-preserving, decentralized storage for Logos").
- No sunset dates, codenames, or workspace renames included, per scope.

## Test plan
- [ ] `docs/reference/naming-migration.md` renders cleanly on GitHub.
- [ ] README link to `/docs/reference/naming-migration.md` resolves on the merged branch.
- [ ] Repo/org URLs in the table resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)