### PR TITLE
Clarify macOS and API port setup for blockchain node quickstart

### DIFF
--- a/docs/blockchain/quickstart-guide-for-the-logos-blockchain-node.md
+++ b/docs/blockchain/quickstart-guide-for-the-logos-blockchain-node.md
@@ -21,6 +21,7 @@ There is currently no dynamic wallet key management. To add new keys you must ma
 Before you start, ensure you have:
 
 - Linux x86_64, or a Raspberry Pi 5 with [Raspberry Pi OS](https://www.raspberrypi.com/software/) installed
+- macOS on Apple silicon (`arm64`), if you use the `macos-aarch64` release assets
 - glibc version 2.39 or later (Linux only)
 - At least 64 GB of storage
 
@@ -46,8 +47,15 @@ The node requires zero-knowledge circuit files for cryptographic operations. Dow
     For example, to download release 0.1.2 on Linux x86_64 with `wget`:
 
     ```sh
-    wget https://github.com/logos-blockchain/logos-blockchain/releases/download/0.1.3-rc.1/logos-blockchain-circuits-v0.4.2-linux-x86_64.tar.gz
+    wget https://github.com/logos-blockchain/logos-blockchain/releases/download/0.1.2/logos-blockchain-circuits-v0.4.2-linux-x86_64.tar.gz
     wget https://github.com/logos-blockchain/logos-blockchain/releases/download/0.1.2/logos-blockchain-node-linux-x86_64-0.1.2.tar.gz
+    ```
+
+    On macOS on Apple silicon:
+
+    ```sh
+    curl -LO https://github.com/logos-blockchain/logos-blockchain/releases/download/0.1.2/logos-blockchain-circuits-v0.4.2-macos-aarch64.tar.gz
+    curl -LO https://github.com/logos-blockchain/logos-blockchain/releases/download/0.1.2/logos-blockchain-node-macos-aarch64-0.1.2.tar.gz
     ```
 
     On a Raspberry Pi (aarch64):
@@ -91,6 +99,13 @@ The `init` subcommand generates a user configuration that includes per-node sett
     ```
 
     - To change the API port, set `api.backend.listen_address` in `user_config.yaml` before starting. The default is `8080`.
+    - If another local service already uses port `8080`, the API cannot bind to that port. For example, check before starting:
+
+      ```sh
+      lsof -nP -iTCP:8080 -sTCP:LISTEN
+      ```
+
+      If the port is in use, set another local API address, for example `127.0.0.1:18080`, and use that port in the `curl` commands below.
 
 1. Start the node:
 
@@ -107,6 +122,8 @@ Wait for your node to finish syncing and reach `Online` mode before requesting t
     ```sh
     curl -s http://localhost:8080/cryptarchia/info | jq .
     ```
+
+    If you changed `api.backend.listen_address`, replace `8080` with your configured port.
 
     Example response:
 
@@ -129,6 +146,8 @@ Wait for your node to finish syncing and reach `Online` mode before requesting t
     ```sh
     curl -s http://localhost:8080/network/info | jq .
     ```
+
+    If you changed `api.backend.listen_address`, replace `8080` with your configured port.
 
     Example response:
 


### PR DESCRIPTION
## Summary

- add the macOS Apple silicon release path to the node quickstart
- add matching macOS download commands for the node and circuits assets
- keep the Linux x86_64 example release links consistent with release `0.1.2`
- add a small API port collision check before running the local verification commands

Related to #213.

## Why

I dogfooded the headless Logos Blockchain node quickstart from `logos-co/logos-docs#213`.

On an Apple silicon Mac, the latest `0.1.2` release includes runnable `macos-aarch64` node and circuits assets, but the quickstart prerequisites only mention Linux x86_64 and Raspberry Pi. The macOS binary ran locally, `init` generated `user_config.yaml`, and `--check-config` passed.

I also hit a local port collision on `8080`. The node logged that it could not bind the API server, but the process continued running. Because another local service was already listening on `8080`, the guide's `curl localhost:8080/...` checks returned a response from the wrong service. After changing `api.backend.listen_address` to `127.0.0.1:18080`, the documented API checks worked with the adjusted port.

## Evidence

- Release checked: `logos-blockchain/logos-blockchain` latest release `0.1.2`
- Downloaded and extracted:
  - `logos-blockchain-circuits-v0.4.2-macos-aarch64.tar.gz`
  - `logos-blockchain-node-macos-aarch64-0.1.2.tar.gz`
- Ran:
  - `./logos-blockchain-node --version`
  - `./logos-blockchain-node --help`
  - `./logos-blockchain-node init ...`
  - `./logos-blockchain-node --check-config user_config.yaml`
  - `./logos-blockchain-node user_config.18080.yaml`
  - `curl -s http://localhost:18080/cryptarchia/info`
  - `curl -s http://localhost:18080/network/info`

`./logos-blockchain-node --version` output:

```txt
logos-blockchain-node 0.1.2
commit:  05f84a5 (tag 0.1.2)
target:  aarch64-apple-darwin
profile: release
rustc:   rustc 1.94.0 (4a4ef493e 2026-03-02)
```

Observed API output after using port `18080`:

```json
{
  "lib": "646088a81f76e6a6ae35b3cc87f33c9081c12b02932604eee427593251f72bec",
  "lib_slot": 0,
  "tip": "646088a81f76e6a6ae35b3cc87f33c9081c12b02932604eee427593251f72bec",
  "slot": 0,
  "height": 0,
  "mode": "Bootstrapping"
}
```

```json
{
  "listen_addresses": [
    "/ip4/127.0.0.1/udp/3000/quic-v1",
    "/ip4/192.168.1.4/udp/3000/quic-v1"
  ],
  "peer_id": "12D3KooWAqVd6dspmppz6Zu7988avyfoBqPB7tCwT7Yyauq6LWg1",
  "n_peers": 4,
  "n_connections": 4,
  "n_pending_connections": 0
}
```

## Notes

I did not continue to faucet/token steps because the guide says to wait until the node reaches `Online` mode first.