### PR TITLE
Convert GitHub alert callouts to GitBook hint syntax

### DIFF
--- a/docs/basecamp/get-started/install-the-logos-basecamp-app.md
+++ b/docs/basecamp/get-started/install-the-logos-basecamp-app.md
@@ -14,10 +14,12 @@ slug: install-the-logos-basecamp-app
 
 #### Get Logos Basecamp running on your desktop.
 
-> [!NOTE]
->
-> - **Permissions**: No special permissions required.
-> - **Product**: Logos Basecamp.
+{% hint style="info" %}
+## Note
+
+- **Permissions**: No special permissions required.
+- **Product**: Logos Basecamp.
+{% endhint %}
 
 Logos Basecamp is the desktop shell for the Logos platform. You can discover, install, and run Logos modules and apps using its graphical interface as an alternative to the command line.
 
@@ -28,9 +30,11 @@ You can install Logos Basecamp in two ways:
 | [Prebuilt release (AppImage or DMG)](#install-from-a-prebuilt-release) | End users | None |
 | [Build from source with Nix](#build-and-run-logos-basecamp-from-source) | Contributors, custom builds, unsupported platforms | Nix with flakes enabled |
 
-> [!NOTE]
->
-> To enable flakes in nix, add `experimental-features = nix-command flakes` to `/etc/nix/config`.
+{% hint style="info" %}
+## Note
+
+To enable flakes in nix, add `experimental-features = nix-command flakes` to `/etc/nix/config`.
+{% endhint %}
 
 Before you start, make sure you have the following:
 
@@ -39,9 +43,11 @@ Before you start, make sure you have the following:
 - 4 GB RAM minimum (8 GB recommended) and ~2 GB free disk space.
 - For the source build only: [Nix](https://github.com/NixOS/nix-installer) installed with flakes enabled.
 
-> [!NOTE]
->
-> Internet access is required to download the binary or clone the repository, but not to launch Logos Basecamp afterward. Logos Basecamp itself opens no inbound ports. 
+{% hint style="info" %}
+## Note
+
+Internet access is required to download the binary or clone the repository, but not to launch Logos Basecamp afterward. Logos Basecamp itself opens no inbound ports. 
+{% endhint %}
 
 ## Install from a prebuilt release
 

--- a/docs/blockchain/get-started/run-a-logos-blockchain-node-from-cli.md
+++ b/docs/blockchain/get-started/run-a-logos-blockchain-node-from-cli.md
@@ -34,9 +34,11 @@ Before you start, ensure you have:
 
 The node requires zero-knowledge circuit files for cryptographic operations. Download the node binary and circuits archive from the [Logos Blockchain Node releases page](https://github.com/logos-blockchain/logos-blockchain/releases/latest), then install both before running the node.
 
-> [!NOTE]
->
-> The wallet used here is the node's internal key store, not a general-purpose user wallet. It holds the staking keys that give your node the right to participate in the consensus lottery.
+{% hint style="info" %}
+## Note
+
+The wallet used here is the node's internal key store, not a general-purpose user wallet. It holds the staking keys that give your node the right to participate in the consensus lottery.
+{% endhint %}
 
 1. Download the latest node binary and circuits archive for your device's architecture.
 
@@ -83,9 +85,11 @@ The node requires zero-knowledge circuit files for cryptographic operations. Dow
 
 The `init` subcommand generates a user configuration that includes per-node settings such as keys, ports, and peer addresses, along with fresh cryptographic keys and an auto-detected public IP.
 
-> [!NOTE]
->
-> Make sure to use the current bootstrap peer addresses in the [Logos Blockchain Node release notes](https://github.com/logos-blockchain/logos-blockchain/releases/latest) for your selected release.
+{% hint style="info" %}
+## Note
+
+Make sure to use the current bootstrap peer addresses in the [Logos Blockchain Node release notes](https://github.com/logos-blockchain/logos-blockchain/releases/latest) for your selected release.
+{% endhint %}
 
 1. Generate your `user_config.yaml` by running `init` with the bootstrap peer addresses. For example, for release 0.1.2:
 
@@ -196,11 +200,13 @@ A faucet distributes free tokens on test networks so you can experiment without 
 
     - Only one faucet transaction can be included per block. During high demand, your transaction may be dropped; retry the request and wait 1 to 2 minutes before checking again.
 
-> [!NOTE]
->
-> Your tokens become eligible for consensus after 3.5 hours. Confirm that your node is participating by checking that `mode` remains `Online` and `height` continues to increase.
->
-> Block proposal is probabilistic. Your node will not propose on every slot; participation depends on your stake relative to total active stake in the network.
+{% hint style="info" %}
+## Note
+
+Your tokens become eligible for consensus after 3.5 hours. Confirm that your node is participating by checking that `mode` remains `Online` and `height` continues to increase.
+
+Block proposal is probabilistic. Your node will not propose on every slot; participation depends on your stake relative to total active stake in the network.
+{% endhint %}
 
 ## Troubleshooting the Logos Blockchain node
 

--- a/docs/build-an-app/tutorials/create-and-use-an-amm-liquidity-pool-on-the-logos-execution-zone.md
+++ b/docs/build-an-app/tutorials/create-and-use-an-amm-liquidity-pool-on-the-logos-execution-zone.md
@@ -1,8 +1,10 @@
 # Create and use an AMM liquidity pool on the Logos Execution Zone
 
-> [!IMPORTANT]
->
-> This page is an early draft and may be incomplete or incorrect. Expect changes, missing prerequisites, and commands that might not work in your setup. We are actively working to complete and verify this content.
+{% hint style="warning" %}
+## Important
+
+This page is an early draft and may be incomplete or incorrect. Expect changes, missing prerequisites, and commands that might not work in your setup. We are actively working to complete and verify this content.
+{% endhint %}
 
 This tutorial covers the AMM program in LEZ. The AMM manages liquidity pools and enables swaps between custom tokens. By the end, you will have practiced:
 
@@ -15,8 +17,11 @@ This tutorial covers the AMM program in LEZ. The AMM manages liquidity pools and
 
 We start by creating a pool for the tokens created earlier. In return for providing liquidity, you receive liquidity provider (LP) tokens. LP tokens represent your share of the pool and are required to withdraw liquidity later.
 
-> [!NOTE]
-> The AMM does not currently charge swap fees or distribute rewards to liquidity providers. LP tokens therefore represent only a proportional share of the pool reserves. Fee support will be added in future versions.
+{% hint style="info" %}
+## Note
+
+The AMM does not currently charge swap fees or distribute rewards to liquidity providers. LP tokens therefore represent only a proportional share of the pool reserves. Fee support will be added in future versions.
+{% endhint %}
 
 ### a. Create an LP holding account
 
@@ -40,8 +45,11 @@ wallet amm new \
     --balance-b 200
 ```
 
-> [!Important]
-> The LP holding account is owned by the token program, so LP tokens are managed using the same token infrastructure as regular tokens.
+{% hint style="warning" %}
+## Important
+
+The LP holding account is owned by the token program, so LP tokens are managed using the same token infrastructure as regular tokens.
+{% endhint %}
 
 ```bash
 wallet account get --account-id Public/FHgLW9jW4HXMV6egLWbwpTqVAGiCHw2vkg71KYSuimVf
@@ -51,8 +59,11 @@ Holding account owned by token program
 {"account_type":"Token holding","definition_id":"7BeDS3e28MA5Err7gBswmR1fUKdHXqmUpTefNPu3pJ9i","balance":100}
 ```
 
-> [!Tip]
-> If you inspect the `user-holding-a` and `user-holding-b` accounts, you will see that 100 and 200 tokens were deducted. Those tokens now reside in the pool and are available for swaps by any user.
+{% hint style="success" %}
+## Tip
+
+If you inspect the `user-holding-a` and `user-holding-b` accounts, you will see that 100 and 200 tokens were deducted. Those tokens now reside in the pool and are available for swaps by any user.
+{% endhint %}
 
 ## 2. Swapping
 
@@ -89,9 +100,12 @@ wallet amm remove-liquidity \
     --min-amount-b 1
 ```
 
-> [!Important]
-> This burns `balance-lp` LP tokens from the user’s LP holding account. In return, the AMM transfers tokens A and B from the pool vaults to the user’s holding accounts, based on current reserves.
-> The `min-amount-a` and `min-amount-b` parameters set the minimum acceptable outputs. If the computed amounts fall below either threshold, the instruction fails to protect against unfavorable pool changes.
+{% hint style="warning" %}
+## Important
+
+This burns `balance-lp` LP tokens from the user’s LP holding account. In return, the AMM transfers tokens A and B from the pool vaults to the user’s holding accounts, based on current reserves.
+The `min-amount-a` and `min-amount-b` parameters set the minimum acceptable outputs. If the computed amounts fall below either threshold, the instruction fails to protect against unfavorable pool changes.
+{% endhint %}
 
 ## 4. Adding liquidity to the pool
 
@@ -109,6 +123,9 @@ wallet amm add-liquidity \
     --max-amount-b 10
 ```
 
-> [!Important]
-> `max-amount-a` and `max-amount-b` cap how many tokens A and B can be taken from the user’s accounts. The AMM computes the required amounts based on the pool’s reserve ratio.
-> `min-amount-lp` sets the minimum LP tokens to mint. If the computed LP amount falls below this threshold, the instruction fails.
+{% hint style="warning" %}
+## Important
+
+`max-amount-a` and `max-amount-b` cap how many tokens A and B can be taken from the user’s accounts. The AMM computes the required amounts based on the pool’s reserve ratio.
+`min-amount-lp` sets the minimum LP tokens to mint. If the computed LP amount falls below this threshold, the instruction fails.
+{% endhint %}

--- a/docs/core/build-modules/build-a-logos-cpp-ui-module.md
+++ b/docs/core/build-modules/build-a-logos-cpp-ui-module.md
@@ -32,9 +32,11 @@ This guide shows you how to build a `calc_ui_cpp` module — a QML view backed b
 
 Initialise a new directory and apply the `ui-qml-backend` template from `logos-module-builder`.
 
-> [!NOTE]
->
->  The generated `flake.nix` uses an unpinned `logos-module-builder` URL. Replace it with the pinned version in [Step 7](#step-7-configure-flakenix) to ensure reproducible builds.
+{% hint style="info" %}
+## Note
+
+ The generated `flake.nix` uses an unpinned `logos-module-builder` URL. Replace it with the pinned version in [Step 7](#step-7-configure-flakenix) to ensure reproducible builds.
+{% endhint %}
 
 1. Run the scaffold command:
 
@@ -561,9 +563,11 @@ Bundle both modules as `.lgx` packages and install them using `lgpm`.
    ./basecamp-result/bin/LogosBasecamp
    ```
 
-    > [!NOTE]
-    >
-    >  The dev build requires dev `.lgx` variants (`result-lgx`). For a portable build of basecamp, use `result-lgx-portable` variants and the `LogosBasecamp` data directory instead. Mixing variants causes loading failures.
+    {% hint style="info" %}
+    ## Note
+
+     The dev build requires dev `.lgx` variants (`result-lgx`). For a portable build of basecamp, use `result-lgx-portable` variants and the `LogosBasecamp` data directory instead. Mixing variants causes loading failures.
+    {% endhint %}
 
 1. Alternatively, you can install modules through the basecamp UI:
 

--- a/docs/core/build-modules/build-run-a-logos-core-module.md
+++ b/docs/core/build-modules/build-run-a-logos-core-module.md
@@ -14,18 +14,22 @@ slug: build-run-a-logos-core-module
 
 #### Scaffold, build, package, and test a core module on the Logos platform.
 
-> [!NOTE]
->
-> - **Permissions**: No special permissions required.
-> - **Product**: Logos Basecamp
+{% hint style="info" %}
+## Note
+
+- **Permissions**: No special permissions required.
+- **Product**: Logos Basecamp
+{% endhint %}
 
 The Logos platform is a modular application framework built on Qt 6. Applications are composed of dynamically loaded modules (Qt plugins) that provide features and functionality.
 
 Logos core modules are non-UI modules that provide backend functionality. Core modules run in isolated `logos_host` processes and communicate via Qt Remote Objects.
 
-> [!NOTE]
->
-> For other module types, check out [Wrap a C Library as a Logos core module](./wrap-a-c-library-as-a-logos-core-module.md), [Build a QML UI for your logos module](./build-a-qml-ui-for-your-logos-module.md) and [Build a Logos C++ UI module](./build-a-logos-cpp-ui-module.md). These guides — along with the [LGX package format and bundling reference](./lgx-package-format-and-bundling-reference.md) and the [Logos CLI Reference](./logos-cli-reference.md) — are still being written; the linked pages are placeholders for now.
+{% hint style="info" %}
+## Note
+
+For other module types, check out [Wrap a C Library as a Logos core module](./wrap-a-c-library-as-a-logos-core-module.md), [Build a QML UI for your logos module](./build-a-qml-ui-for-your-logos-module.md) and [Build a Logos C++ UI module](./build-a-logos-cpp-ui-module.md). These guides — along with the [LGX package format and bundling reference](./lgx-package-format-and-bundling-reference.md) and the [Logos CLI Reference](./logos-cli-reference.md) — are still being written; the linked pages are placeholders for now.
+{% endhint %}
 
 Before you start, make sure you have the following:
 
@@ -67,9 +71,11 @@ The `logos-module-builder` provides four scaffolding templates for different mod
 
    The template uses `minimal` as a placeholder in the source filenames, class names, and identifiers. You replace these placeholders with your module's name in Step 2.
 
-   > [!NOTE]
-   >
-   > The `metadata.json` file is the single source of truth for your module. Read [LGX package format and bundling reference](./lgx-package-format-and-bundling-reference.md) for more details.
+   {% hint style="info" %}
+   ## Note
+
+   The `metadata.json` file is the single source of truth for your module. Read [LGX package format and bundling reference](./lgx-package-format-and-bundling-reference.md) for more details.
+   {% endhint %}
 
 ## Step 2: Adapt the template for your module
 
@@ -108,9 +114,11 @@ The template generates files with placeholder names like `minimal`/`Minimal` and
 1. Edit the plugin implementation (`src/<module-name>_plugin.cpp`) and replace the placeholder method bodies with your logic.
    - In `initLogos`, assign the `LogosAPI*` pointer to the global `logosAPI` variable, not to a class member.
 
-> [!TIP]
->
-> Run `grep -ri "minimal" .` after editing to catch any remaining placeholder references (`minimal`, `Minimal`, `MINIMAL_*`, `MinimalInterface_iid`) before building.
+{% hint style="success" %}
+## Tip
+
+Run `grep -ri "minimal" .` after editing to catch any remaining placeholder references (`minimal`, `Minimal`, `MINIMAL_*`, `MinimalInterface_iid`) before building.
+{% endhint %}
 
 ## Step 3: Build the module
 
@@ -230,9 +238,11 @@ The `logos-module-viewer` is a graphical tool for inspecting loaded modules. It 
 
 Before you can run your module with `logoscore` or install it into `logos-basecamp`, you need to package the build output into an `.lgx` package and install it into a `modules/` directory. Check out the [LGX package format and bundling reference](./lgx-package-format-and-bundling-reference.md) for more details on the format and bundling options.
 
-> [!NOTE]
->
-> The `manifest.json` is auto-generated from your module's `metadata.json` by the bundler. It maps each variant to its main entry point.
+{% hint style="info" %}
+## Note
+
+The `manifest.json` is auto-generated from your module's `metadata.json` by the bundler. It maps each variant to its main entry point.
+{% endhint %}
 
 There are two ways to create `.lgx` packages:
 
@@ -253,9 +263,11 @@ When your module uses `logos-module-builder`, LGX package outputs are automatica
 
 1. Check the `result/` directory and confirm the `logos-<module-name>-module-lib.lgx` file is present.
 
-   > [!NOTE]
-   >
-   > `.#lgx` produces a single variant (for example, `linux-amd64`) and `.#lgx-portable` produces a single portable variant. Neither produces the `-dev` variant that `logos-basecamp` dev builds expect. If you need the dev variant for use with `logos-basecamp`, use the `#dual` bundler described in the next section.
+   {% hint style="info" %}
+   ## Note
+
+   `.#lgx` produces a single variant (for example, `linux-amd64`) and `.#lgx-portable` produces a single portable variant. Neither produces the `-dev` variant that `logos-basecamp` dev builds expect. If you need the dev variant for use with `logos-basecamp`, use the `#dual` bundler described in the next section.
+   {% endhint %}
 
 ### Use the `nix bundle` command
 
@@ -272,9 +284,11 @@ The `nix bundle` command is useful if your module does not use `logos-module-bui
 
 1. Check the current directory for the bundle output. `nix bundle` creates a symlink directory in the current directory named `./logos-<module-name>-module-lib-lgx-<version>/`, and the `.lgx` file is inside it at `./logos-<module-name>-module-lib-lgx-<version>/logos-<module-name>-module-lib.lgx`.
 
-> [!TIP]
-> 
-> Check out [LGX package format and bundling reference](./lgx-package-format-and-bundling-reference.md) for more details on the format and bundling options.
+{% hint style="success" %}
+## Tip
+
+Check out [LGX package format and bundling reference](./lgx-package-format-and-bundling-reference.md) for more details on the format and bundling options.
+{% endhint %}
 
 ## Step 6: Install the module
 
@@ -308,9 +322,11 @@ There are two ways to install `.lgx` packages:
 
 The Logos module catalog is hosted on GitHub Releases in the [logos-modules](https://github.com/logos-co/logos-modules) repository. Use `lgpd` to search and download packages, then `lgpm` to install them locally.
 
-> [!IMPORTANT]
->
-> Registry packages currently ship portable variants only (for example, `linux-amd64`, `darwin-arm64`). They cannot be installed into a dev build of `logos-basecamp`, which expects `-dev` variants. To use a registry module with a dev build, you must build the module from source and bundle it with `#dual`. They install cleanly into `logoscore` and into portable builds of `logos-basecamp`.
+{% hint style="warning" %}
+## Important
+
+Registry packages currently ship portable variants only (for example, `linux-amd64`, `darwin-arm64`). They cannot be installed into a dev build of `logos-basecamp`, which expects `-dev` variants. To use a registry module with a dev build, you must build the module from source and bundle it with `#dual`. They install cleanly into `logoscore` and into portable builds of `logos-basecamp`.
+{% endhint %}
 
 1. Build the Logos Package Manager (`lgpm`) CLI.
 
@@ -330,9 +346,11 @@ The Logos module catalog is hosted on GitHub Releases in the [logos-modules](htt
    ./downloader/bin/lgpd search <registry-name>
    ```
 
-   > [!TIP]
-   >
-   > Use `./downloader/bin/lgpd list` to browse all available packages.
+   {% hint style="success" %}
+   ## Tip
+
+   Use `./downloader/bin/lgpd list` to browse all available packages.
+   {% endhint %}
 
 1. Download the LGX package to a local directory.
 
@@ -384,17 +402,21 @@ The `logoscore` CLI (from `logos-liblogos`) is a headless runtime that can load 
    ./logos/bin/logoscore stop
    ```
 
-> [!TIP]
->
-> Check out [Logos CLI Reference](./logos-cli-reference.md) for more details on available commands and options.
+{% hint style="success" %}
+## Tip
+
+Check out [Logos CLI Reference](./logos-cli-reference.md) for more details on available commands and options.
+{% endhint %}
 
 ### Run with `logos-basecamp`
 
 Logos Basecamp is a desktop application that provides a graphical interface for managing and running modules. Core modules run as background services in `logos-basecamp`. Other UI modules can call them through `LogosAPI` or the `logos.callModule()` bridge once they are installed.
 
-> [!IMPORTANT]
->
-> The LGX variant type must match the basecamp build type. Dev builds of basecamp expect dev LGX variants (for example, `darwin-arm64-dev`), and portable builds expect portable variants (for example, `darwin-arm64`). Check out the [LGX package format and bundling reference](./lgx-package-format-and-bundling-reference.md) for more details.
+{% hint style="warning" %}
+## Important
+
+The LGX variant type must match the basecamp build type. Dev builds of basecamp expect dev LGX variants (for example, `darwin-arm64-dev`), and portable builds expect portable variants (for example, `darwin-arm64`). Check out the [LGX package format and bundling reference](./lgx-package-format-and-bundling-reference.md) for more details.
+{% endhint %}
 
 1. Build the development version of `logos-basecamp`.
 
@@ -468,9 +490,11 @@ If `lgpm install` fails with `Package does not contain variant for platform: <pl
 
 Registry packages downloaded with `lgpd` currently ship portable variants only.
 
-> [!NOTE]
->
-> `lgpm` error messages report the platform as `linux-x86_64` while LGX manifests label it `linux-amd64`. These refer to the same architecture.
+{% hint style="info" %}
+## Note
+
+`lgpm` error messages report the platform as `linux-x86_64` while LGX manifests label it `linux-amd64`. These refer to the same architecture.
+{% endhint %}
 
 ### `nix build .#lib` does nothing or fails silently                               
   

--- a/docs/core/build-modules/install-and-load-a-module-in-logos-basecamp.md
+++ b/docs/core/build-modules/install-and-load-a-module-in-logos-basecamp.md
@@ -24,8 +24,11 @@ Before you start, make sure you have:
 - Internet access for online catalog install.
 - [An `.lgx` file](./build-and-run-a-logos-core-module.md) for local install.
 
-> [!NOTE]
-> The `.lgx` file's archive must contain a variant matching your platform. For example, `linux-x86_64`, `linux-aarch64`, `darwin-x86_64`, or `darwin-arm64`.
+{% hint style="info" %}
+## Note
+
+The `.lgx` file's archive must contain a variant matching your platform. For example, `linux-x86_64`, `linux-aarch64`, `darwin-x86_64`, or `darwin-arm64`.
+{% endhint %}
 
 ## What to expect
 
@@ -59,9 +62,11 @@ Loading a module turns an installed module into a running service you can actual
 1. Find the module to load under **UI Modules** or **Core Modules** depending on its type.
 1. Click **Load** next to the module.
 
-> [!NOTE]
->
-> You can click **Unload** in the Modules view or close the tab of a module to unload it. Unloading stops the module's host process but not its dependencies, which may still be in use by other modules or UI Apps.
+{% hint style="info" %}
+## Note
+
+You can click **Unload** in the Modules view or close the tab of a module to unload it. Unloading stops the module's host process but not its dependencies, which may still be in use by other modules or UI Apps.
+{% endhint %}
 
 ## Troubleshooting
 

--- a/docs/lez/get-started/introduction-to-the-logos-execution-zone.md
+++ b/docs/lez/get-started/introduction-to-the-logos-execution-zone.md
@@ -30,9 +30,11 @@ Private accounts, by contrast, are stored locally on the account-holder’s node
 -  Nullifier keys: The private nullifier key is used by the account owner to sign transactions and authorise executions. The public nullifier key is used as the account ID for verifying ownership.
 -  Viewing keys: The private viewing key is used by the account owner to create ZK proofs. The public viewing key is used to verify proofs without revealing the account owner.
 
-> [!NOTE]
->
-> A program must obtain a private account’s nullifier public key, as well as its viewing public key, in order to modify a private account state. Therefore, you cannot transfer tokens to a private account without being provided this information by the owner.
+{% hint style="info" %}
+## Note
+
+A program must obtain a private account’s nullifier public key, as well as its viewing public key, in order to modify a private account state. Therefore, you cannot transfer tokens to a private account without being provided this information by the owner.
+{% endhint %}
 
 When an LEE program executes, it modifies the accounts provided to it. These accounts could be either public or private, as an LEE program can be executed over both types of accounts. In either case, the program is executed using the same bytecode, the main difference being whether the user who runs a program will generate a zero knowledge proof. Executions modifying public accounts are executed transparently by LEZ validators like any standard RISC-V VM call. On the other hand, private executions involve the generation of zero knowledge proofs via Risc0, which are then verified by LEZ validators. 
 
@@ -50,6 +52,8 @@ As an example, the LEZ could be used to host private DeFi applications. With sup
 - Confidential Lending/Borrowing Protocols: Financial services where loan details or collateral information are private.
 - Confidential Transfers: Securely sending and receiving digital assets with transaction details obscured using zero knowledge proofs, ensuring financial privacy for individuals and businesses.
 
-> [!TIP]
->
-> Check out the tutorial on how to create your own [Automated Market Maker (AMM) trading pool](../../build/create-and-use-an-amm-liquidity-pool-on-the-logos-execution-zone.md) program on the LEZ.
+{% hint style="success" %}
+## Tip
+
+Check out the tutorial on how to create your own [Automated Market Maker (AMM) trading pool](../../build/create-and-use-an-amm-liquidity-pool-on-the-logos-execution-zone.md) program on the LEZ.
+{% endhint %}

--- a/docs/lez/get-started/quickstart-for-the-logos-execution-zone-wallet.md
+++ b/docs/lez/get-started/quickstart-for-the-logos-execution-zone-wallet.md
@@ -21,35 +21,45 @@ slug: lez-quickstart
 
 #### Set up the wallet, connect to a sequencer, and run a minimal transfer flow.
 
-> [!IMPORTANT]
->
-> This page should be accurate for the specific version referenced in this doc, but it may not have been run end-to-end as written. Expect minor gaps (for example, missing environment details) and be prepared to troubleshoot. We are actively working to complete and verify this content.
+{% hint style="warning" %}
+## Important
 
-> [!NOTE]
->
-> - **Permissions**: No special permissions required.
-> - **Product**: Logos Execution Zone wallet CLI.
+This page should be accurate for the specific version referenced in this doc, but it may not have been run end-to-end as written. Expect minor gaps (for example, missing environment details) and be prepared to troubleshoot. We are actively working to complete and verify this content.
+{% endhint %}
 
-> [!TIP]
->
-> A public LEZ testnet is available. This quickstart runs against a local sequencer you start yourself, but you can browse live testnet activity in the block explorer, and the testnet sequencer is reachable at its public RPC endpoint.
->
-> - Explorer: https://explorer.testnet.lez.logos.co/
-> - Sequencer RPC: https://testnet.lez.logos.co/
+{% hint style="info" %}
+## Note
+
+- **Permissions**: No special permissions required.
+- **Product**: Logos Execution Zone wallet CLI.
+{% endhint %}
+
+{% hint style="success" %}
+## Tip
+
+A public LEZ testnet is available. This quickstart runs against a local sequencer you start yourself, but you can browse live testnet activity in the block explorer, and the testnet sequencer is reachable at its public RPC endpoint.
+
+- Explorer: https://explorer.testnet.lez.logos.co/
+- Sequencer RPC: https://testnet.lez.logos.co/
+{% endhint %}
 
 The Logos Execution Zone (LEZ, for short) is a programmable blockchain that records transactions, maintains public on-chain state, and exposes a sequencer endpoint that clients (like a wallet) can submit transactions to.
 
 LEZ separates account state into public (visible, on-chain) and private (hidden, off-chain). You choose which one you are using by creating a public or private account and using it in transactions. This ability to maintain a public and private state is provided by the Logos Execution Environment (LEE), that defines what an account is, how transactions are structured, and how executions are validated when some data must remain private. You can think of LEZ as the blockchain you connect to and where transactions are recorded, and LEE as the execution model that powers it.
 
-> [!NOTE]
->
-> This quickstart covers the public wallet flow only so you can get set up quickly. Privacy-preserving transfers require local proof generation and take longer to run. For the private workflow, see [Transfer native tokens on the Logos Execution Zone](../transfer-tokens/transfer-native-tokens-on-the-logos-execution-zone.md).
+{% hint style="info" %}
+## Note
+
+This quickstart covers the public wallet flow only so you can get set up quickly. Privacy-preserving transfers require local proof generation and take longer to run. For the private workflow, see [Transfer native tokens on the Logos Execution Zone](../transfer-tokens/transfer-native-tokens-on-the-logos-execution-zone.md).
+{% endhint %}
 
 When a transaction touches the private state, the client runs the private part locally using your private keys and local client data, producing a zero-knowledge proof (ZKP). Validators verify the proof and accept the state update (for example, updating public balances), so the network stays correct even though the private data is never published.
 
-> [!NOTE]
->
-> In the context of the Logos Execution Zone, a zero-knowledge proof (ZKP) is a cryptographic proof that lets a blockchain client, such as a wallet, prove a private transaction followed LEE’s rules without revealing the private inputs (like balances). Using ZKPs, LEZ can safely accept the resulting state update and keep the public chain consistent with private execution, even though the network never sees the private values.
+{% hint style="info" %}
+## Note
+
+In the context of the Logos Execution Zone, a zero-knowledge proof (ZKP) is a cryptographic proof that lets a blockchain client, such as a wallet, prove a private transaction followed LEE’s rules without revealing the private inputs (like balances). Using ZKPs, LEZ can safely accept the resulting state update and keep the public chain consistent with private execution, even though the network never sees the private values.
+{% endhint %}
 
 In this quickstart, you install the wallet tooling, connect to a local sequencer endpoint, and complete a minimal transfer flow with balance checks. In wallet terms, the wallet client is your control panel for the system: you install it, create and manage public or private accounts, sync private state, and send commands.
 
@@ -68,9 +78,11 @@ To run the LEZ wallet CLI, you first need to install system dependencies, the Ru
 
 Install the build prerequisites you need to compile the sequencer and wallet.
 
-> [!TIP]
->
-> These prerequisites include a working C toolchain and linker on your machine. You may already have these installed if you have experience building software from source.
+{% hint style="success" %}
+## Tip
+
+These prerequisites include a working C toolchain and linker on your machine. You may already have these installed if you have experience building software from source.
+{% endhint %}
 
 Choose the instructions for your operating system:
 
@@ -93,9 +105,11 @@ Choose the instructions for your operating system:
 
 ### Install Rust and RISC Zero components
 
-> [!NOTE]
->
-> Rust is the language used for wallet development, while RISC Zero is the proof toolchain used to generate the ZKPs.
+{% hint style="info" %}
+## Note
+
+Rust is the language used for wallet development, while RISC Zero is the proof toolchain used to generate the ZKPs.
+{% endhint %}
 
 1. Install Rust with `rustup`:
 
@@ -124,9 +138,11 @@ Choose the instructions for your operating system:
 
 The Logos Blockchain repository provides a script that downloads a circuits release required by the `wallet` build.
 
-> [!TIP]
->
-> "Circuits" are prebuilt files used for privacy-preserving execution (zero-knowledge proofs). Even though the quickstart flow uses public transactions, the current `wallet` build still requires these files to be present locally.
+{% hint style="success" %}
+## Tip
+
+"Circuits" are prebuilt files used for privacy-preserving execution (zero-knowledge proofs). Even though the quickstart flow uses public transactions, the current `wallet` build still requires these files to be present locally.
+{% endhint %}
 
 1. Create a workspace folder and clone the Logos Blockchain repository:
 
@@ -138,9 +154,11 @@ The Logos Blockchain repository provides a script that downloads a circuits rele
 
 1. Run the script to download the circuits release:
 
-   > [!NOTE]
-   >
-   > This script downloads `logos-blockchain-circuits-<version>-<platform>.tar.gz` and installs it under `~/.logos-blockchain-circuits` by default.
+   {% hint style="info" %}
+   ## Note
+
+   This script downloads `logos-blockchain-circuits-<version>-<platform>.tar.gz` and installs it under `~/.logos-blockchain-circuits` by default.
+   {% endhint %}
 
    ```bash
    cd logos-blockchain
@@ -176,9 +194,11 @@ cd ~/logos/src/logos-execution-zone
 RUST_LOG=info cargo run --features standalone -p sequencer_service sequencer/service/configs/debug/sequencer_config.json
 ```
 
-> [!NOTE]
->
-> This quickstart uses standalone mode, which runs only the LEZ sequencer locally. The full local stack also runs a Logos Blockchain node and the indexer service for development and block exploration, but it adds extra components and is covered separately.
+{% hint style="info" %}
+## Note
+
+This quickstart uses standalone mode, which runs only the LEZ sequencer locally. The full local stack also runs a Logos Blockchain node and the indexer service for development and block exploration, but it adds extra components and is covered separately.
+{% endhint %}
 
 You should see the sequencer starting up at `localhost:3040` and logging information to the terminal:
 
@@ -202,17 +222,21 @@ If you want the wallet to initialize in a different location, set the variable b
 export NSSA_WALLET_HOME_DIR="$PWD/.wallet-home"
 ```
 
-> [!NOTE]
->
-> The `wallet help` output incorrectly states that `NSSA_WALLET_HOME_DIR` "must be set." In practice, the binary falls back to `~/.nssa/wallet` when unset, as described above. The mismatch is in the help string.
+{% hint style="info" %}
+## Note
+
+The `wallet help` output incorrectly states that `NSSA_WALLET_HOME_DIR` "must be set." In practice, the binary falls back to `~/.nssa/wallet` when unset, as described above. The mismatch is in the help string.
+{% endhint %}
 
 ## Step 4: Initialize the wallet local storage and verify connectivity
 
 The wallet persistent storage is defined by the `storage.json` file. When you run any `wallet` subcommand, the wallet checks whether `storage.json` exists in the wallet home directory. If it does not exist, it requires a password to initialize the wallet storage.
 
-> [!TIP]
->
-> Leave the sequencer running in the other terminal window while you initialize the wallet storage.
+{% hint style="success" %}
+## Tip
+
+Leave the sequencer running in the other terminal window while you initialize the wallet storage.
+{% endhint %}
 
 Run a `wallet` command to initialize the storage. Use the built-in health check:
 
@@ -222,9 +246,11 @@ wallet check-health
 
 If the wallet storage was not previously initialized, this command prints `Persistent storage not found, need to execute setup`, and prompts you to create a password. You can choose any password you like, but make sure to remember it, as you will need it to access the wallet in the future.
 
-> [!IMPORTANT]
->
-> The wallet uses this password as a seed to deterministically generate your public and private key trees. The wallet stores the derived key material and local state in storage.json under the wallet home directory.
+{% hint style="warning" %}
+## Important
+
+The wallet uses this password as a seed to deterministically generate your public and private key trees. The wallet stores the derived key material and local state in storage.json under the wallet home directory.
+{% endhint %}
 
 ## Step 5: Complete a minimal wallet flow
 
@@ -257,9 +283,11 @@ In this task, wallet account and transfer commands interact with the authenticat
 
 1. Initialize the sender account, then check the updated state:
 
-   > [!NOTE]
-   >
-   > Running `wallet auth-transfer init` initializes the sender account under the authenticated-transfer program, so the account can debit native tokens when you send transfers.
+   {% hint style="info" %}
+   ## Note
+
+   Running `wallet auth-transfer init` initializes the sender account under the authenticated-transfer program, so the account can debit native tokens when you send transfers.
+   {% endhint %}
 
    ```bash
    wallet auth-transfer init --account-id <sender_public_account_id>

--- a/docs/lez/transfer-tokens/create-and-transfer-custom-tokens-on-the-logos-execution-zone.md
+++ b/docs/lez/transfer-tokens/create-and-transfer-custom-tokens-on-the-logos-execution-zone.md
@@ -14,14 +14,18 @@ slug: create-and-transfer-custom-tokens-on-the-logos-execution-zone
 
 #### Use the wallet CLI to create custom tokens and transfer them between public and private accounts.
 
-> [!IMPORTANT]
->
-> This page is an early draft and may be incomplete or incorrect. Expect changes, missing prerequisites, and commands that might not work in your setup. We are actively working to complete and verify this content.
+{% hint style="warning" %}
+## Important
 
-> [!NOTE]
->
-> - **Permissions**: No special permissions required.
-> - **Product**: Logos Execution Zone wallet CLI.
+This page is an early draft and may be incomplete or incorrect. Expect changes, missing prerequisites, and commands that might not work in your setup. We are actively working to complete and verify this content.
+{% endhint %}
+
+{% hint style="info" %}
+## Note
+
+- **Permissions**: No special permissions required.
+- **Product**: Logos Execution Zone wallet CLI.
+{% endhint %}
 
 The Logos Execution Zone (LEZ) is a programmable blockchain that cleanly separates public and private state while keeping them fully interoperable. It's a component of the [Logos project](https://github.com/logos-co/logos-docs/blob/main/README.md). You can use the wallet CLI to invoke LEZ's token program to create and transfer custom tokens between [public and private accounts](./transfer-native-tokens-on-the-logos-execution-zone.md) on LEZ.
 
@@ -45,9 +49,11 @@ Token program accounts fall into two types:
   - Only the token program can modify it. Modifications happen through token program executions authorized by the account’s keys.
   - It can be public or private.
 
-> [!CAUTION]
->
-> Transfers are irreversible. Double-check all details before proceeding.
+{% hint style="danger" %}
+## Caution
+
+Transfers are irreversible. Double-check all details before proceeding.
+{% endhint %}
 
 Before you begin, ensure that you have the following:
 
@@ -60,9 +66,11 @@ Before you begin, ensure that you have the following:
 - If the recipient account is uninitialized, the token program will automatically claim it. After initialization, only the token program can modify the account.
 - You can transfer custom tokens to any uninitialized public or private account. Once the account is initialized, it can only receive tokens of the same definition ID. (A token holding account stores the balance for exactly one token definition ID.)
 
-> [!NOTE]
->
-> Currently, it's impossible to change the token name or total supply after you create the token.
+{% hint style="info" %}
+## Note
+
+Currently, it's impossible to change the token name or total supply after you create the token.
+{% endhint %}
 
 ## Step 1: Create a token
 
@@ -82,9 +90,11 @@ Before you begin, ensure that you have the following:
 
    If you create a public account, the output is the account ID. If you create a private account, the output includes the account ID, nullifier public key (`npk`), and viewing public key (`vpk`).
 
-> [!NOTE]
-> 
-> Your account keys and data are stored in the local file `$HOME/.nssa/wallet/storage.json`.
+{% hint style="info" %}
+## Note
+
+Your account keys and data are stored in the local file `$HOME/.nssa/wallet/storage.json`.
+{% endhint %}
 
 1. Use the `wallet account ls` command to confirm the accounts are created successfully. You should see a list showing all of your accounts.
 
@@ -130,17 +140,21 @@ Before you begin, ensure that you have the following:
     {"Fungible":{"definition_id":"4X9kAcnCZ1Ukkbm3nywW9xfCNPK8XaMWCk3zfs1sP4J7","balance":1337}}
     ```
 
-> [!TIP]
->
-> When checking the status of a private account, the `wallet account get` command doesn't query the network. It works offline because private account data lives only in your wallet storage. Other users cannot read your private balances using this command and your private account ID.
+{% hint style="success" %}
+## Tip
+
+When checking the status of a private account, the `wallet account get` command doesn't query the network. It works offline because private account data lives only in your wallet storage. Other users cannot read your private balances using this command and your private account ID.
+{% endhint %}
 
 ### Step 2: Transfer tokens
 
 When transferring custom tokens using the `wallet token send` command, you specify the sender and recipient accounts with the account IDs. Both accounts can be public or private, but they must have the same token definition ID.
 
-> [!NOTE]
->
-> Transfers involving private accounts may take a few minutes because the wallet needs to generate a local proof. 
+{% hint style="info" %}
+## Note
+
+Transfers involving private accounts may take a few minutes because the wallet needs to generate a local proof. 
+{% endhint %}
 
 1. Use the `wallet token send` command to transfer custom tokens. Replace `ACCOUNT-TYPE` with the type of the account (public or private) and `TOKEN-AMOUNT` with the amount of tokens to transfer.
 
@@ -173,6 +187,8 @@ When transferring custom tokens using the `wallet token send` command, you speci
     {"Fungible":{"definition_id":"4X9kAcnCZ1Ukkbm3nywW9xfCNPK8XaMWCk3zfs1sP4J7","balance":1000}}
     ```
 
-> [!TIP]
->
-> You can also use the `wallet account ls -l` command to check the balances of all your accounts at once.
+{% hint style="success" %}
+## Tip
+
+You can also use the `wallet account ls -l` command to check the balances of all your accounts at once.
+{% endhint %}

--- a/docs/lez/transfer-tokens/transfer-native-tokens-on-the-logos-execution-zone.md
+++ b/docs/lez/transfer-tokens/transfer-native-tokens-on-the-logos-execution-zone.md
@@ -14,14 +14,18 @@ slug: transfer-native-tokens-on-the-logos-execution-zone
 
 #### Use the wallet CLI to send native tokens to public and private accounts.
 
-> [!IMPORTANT]
->
-> This page should be accurate for the specific version referenced in this doc, but it may not have been run end-to-end as written. Expect minor gaps (for example, missing environment details) and be prepared to troubleshoot. We are actively working to complete and verify this content.
+{% hint style="warning" %}
+## Important
 
-> [!NOTE]
->
->  - **Permissions**: No special permissions required.
->  - **Product**: Logos Execution Zone wallet CLI.
+This page should be accurate for the specific version referenced in this doc, but it may not have been run end-to-end as written. Expect minor gaps (for example, missing environment details) and be prepared to troubleshoot. We are actively working to complete and verify this content.
+{% endhint %}
+
+{% hint style="info" %}
+## Note
+
+ - **Permissions**: No special permissions required.
+ - **Product**: Logos Execution Zone wallet CLI.
+{% endhint %}
 
 The Logos Execution Zone (LEZ) is a programmable blockchain that cleanly separates public and private state while keeping them fully interoperable. It's a component of the [Logos project](https://github.com/logos-co/logos-docs/blob/main/README.md). You can use the wallet CLI to invoke LEZ's authenticated-transfers program to transfer native tokens between public and private accounts.
 
@@ -47,9 +51,11 @@ On LEZ, public and private accounts differ in where their state lives and how tr
     - The transfer generates a zero-knowledge proof of correct execution locally, and submits the proof for validators to verify. Each update to the private state produces a new commitment (a 32-byte, hash-like binding to the actual values), and the previous commitment is marked as spent via a nullifier set so only the latest version can be used, while the actual private values remain local to the account owner.
     - Any public accounts involved are still updated visibly on-chain.
 
-> [!CAUTION]
->
-> Transfers are irreversible. Double-check all details before proceeding.
+{% hint style="danger" %}
+## Caution
+
+Transfers are irreversible. Double-check all details before proceeding.
+{% endhint %}
 
 Before you begin, ensure that you have the following:
 
@@ -81,9 +87,11 @@ Before you begin, ensure that you have the following:
 
    If you create a public account, the output is the account ID. If you create a private account, the output includes the account ID, nullifier public key (`npk`), and viewing public key (`vpk`).
 
-> [!NOTE]
-> 
-> Your account keys and data are stored in the local file `$HOME/.nssa/wallet/storage.json`.
+{% hint style="info" %}
+## Note
+
+Your account keys and data are stored in the local file `$HOME/.nssa/wallet/storage.json`.
+{% endhint %}
 
 2. Use the `wallet account ls` command to confirm the accounts are created successfully. You should see a list showing all of your accounts.
 
@@ -103,11 +111,13 @@ Before you begin, ensure that you have the following:
     wallet auth-transfer init --account-id Public/Ev1JprP9BmhbFVQyBcbznU8bAXcwrzwRoPTetXdQPAWS
     ```
 
-> [!NOTE]
->
-> New accounts are created in an uninitialized state, which means no program on LEZ owns them yet. Any program can claim and own an uninitialized account. After initialization, only the owning program can modify the account.
->
-> The only exception is native token credits: any program can credit native tokens to any account, but only the owning program can debit native tokens.
+{% hint style="info" %}
+## Note
+
+New accounts are created in an uninitialized state, which means no program on LEZ owns them yet. Any program can claim and own an uninitialized account. After initialization, only the owning program can modify the account.
+
+The only exception is native token credits: any program can credit native tokens to any account, but only the owning program can debit native tokens.
+{% endhint %}
 
 4. Fund the sender account using the Testnet Piñata program. Your account receives 150 tokens every time you fund it.
 
@@ -144,18 +154,22 @@ With the recipient account ID, you can transfer native tokens across the followi
 - Public → your private
 - Private → your private
 
-> [!NOTE]
->
-> Transfers involving private accounts may take a few minutes because the wallet needs to generate a local proof. 
+{% hint style="info" %}
+## Note
+
+Transfers involving private accounts may take a few minutes because the wallet needs to generate a local proof. 
+{% endhint %}
 
 With the `npk` and `vpk` of the recipient account, you can transfer native tokens across the following account types:
 
 - Public → uninitialized private (someone else's)
 - Private → uninitialized private (someone else's)
 
-> [!NOTE]
->
-> Currently, only uninitialized private accounts can be modified without authorization. Sending funds to initialized private accounts is not possible because only the owner can modify them.
+{% hint style="info" %}
+## Note
+
+Currently, only uninitialized private accounts can be modified without authorization. Sending funds to initialized private accounts is not possible because only the owner can modify them.
+{% endhint %}
 
 ### Method 1: Transfer tokens using the recipient account ID
 
@@ -181,9 +195,11 @@ For example, to transfer 17 tokens from the public account with ID `Ev1JprP9Bmhb
 
 When transferring someone else's private account, you need their account `npk` (nullifier public key)and `vpk` (viewing public key) instead of the account ID because LEZ uses the `npk`  to confirm the ownership of the private account, and `vpk` to verify transactions without revealing the account owner. These keys do not expose sensitive information and allow others to verify transaction validity.
 
-> [!TIP]
->
-> Check your account `npk` and `vpk` using the `wallet account get --account-id ACCOUNT-TYPE/ACCOUNT-ID` command.
+{% hint style="success" %}
+## Tip
+
+Check your account `npk` and `vpk` using the `wallet account get --account-id ACCOUNT-TYPE/ACCOUNT-ID` command.
+{% endhint %}
 
 1. Use the `wallet auth-transfer send` to transfer tokens to another user's private account. Replace `ACCOUNT-TYPE` with the type of the sender account (public or private) and `TOKEN-AMOUNT` with the amount of tokens to transfer.
 
@@ -222,13 +238,17 @@ The output looks like this:
     {..."balance":BALANCE-AMOUNT...}
     ```
 
-> [!TIP]
->
-> When checking the balance of a private account, the `wallet account get` command doesn't query the network. It works offline because private account data lives only in your wallet storage. Other users cannot read your private balances using this command and your private account ID.
+{% hint style="success" %}
+## Tip
 
-> [!TIP]
->
-> You can also use the `wallet account ls -l` command to check the balances of all your accounts at once.
+When checking the balance of a private account, the `wallet account get` command doesn't query the network. It works offline because private account data lives only in your wallet storage. Other users cannot read your private balances using this command and your private account ID.
+{% endhint %}
+
+{% hint style="success" %}
+## Tip
+
+You can also use the `wallet account ls -l` command to check the balances of all your accounts at once.
+{% endhint %}
 
 ## Troubleshooting
 

--- a/docs/mixnet/get-started/discover-nodes-and-send-messages-via-the-anoncomms-mixnet-demo-app.md
+++ b/docs/mixnet/get-started/discover-nodes-and-send-messages-via-the-anoncomms-mixnet-demo-app.md
@@ -1,8 +1,10 @@
 # Discover nodes and send messages via the AnonComms Mixnet demo app
 
-> [!IMPORTANT]
->
-> This page is an early draft and may be incomplete or incorrect. Expect changes, missing prerequisites, and commands that might not work in your setup. We are actively working to complete and verify this content.
+{% hint style="warning" %}
+## Important
+
+This page is an early draft and may be incomplete or incorrect. Expect changes, missing prerequisites, and commands that might not work in your setup. We are actively working to complete and verify this content.
+{% endhint %}
 
 ## A. Outcome + value (required)
 


### PR DESCRIPTION
Replace `> [!NOTE]` / `[!TIP]` / `[!IMPORTANT]` / `[!CAUTION]` GitHub alert blocks with GitBook `{% hint %}` callouts across the docs, mapping each type respectively:

- NOTE      -> {% hint style="info" %}    + ## Note
- TIP       -> {% hint style="success" %} + ## Tip
- IMPORTANT -> {% hint style="warning" %} + ## Important
- CAUTION   -> {% hint style="danger" %}  + ## Caution

