### PR TITLE
Pin blockchain_module version in run-a-node download instructions

### DIFF
--- a/docs/run-a-node/get-started/run-logos-node-blockchain-storage-delivery.md
+++ b/docs/run-a-node/get-started/run-logos-node-blockchain-storage-delivery.md
@@ -129,7 +129,7 @@ Download and install the three module packages from the configured module [catal
 1. Download the module packages:
 
    ```sh
-   lgpd download blockchain_module --output /opt/logos-node/packages
+   lgpd download blockchain_module --version 0.2.0 --output /opt/logos-node/packages
    lgpd download storage_module --output /opt/logos-node/packages
    lgpd download delivery_module --output /opt/logos-node/packages
    ```


### PR DESCRIPTION
## Summary

On the [Run a Logos node](https://docs.logos.co/run-a-node/get-started/run-logos-node-blockchain-storage-delivery) page, the download step fetches `blockchain_module` without a version:

```sh
lgpd download blockchain_module --output /opt/logos-node/packages
```

but the install step right below expects a specific artifact, `blockchain_module-0.2.0.lgx`. If the catalogue publishes a newer version, the downloaded filename won't match and the install command fails.

This pins the download to match:

```sh
lgpd download blockchain_module --version 0.2.0 --output /opt/logos-node/packages
```

This also matches the [Run a Logos Blockchain node from CLI](https://docs.logos.co/blockchain/get-started/run-a-logos-blockchain-node-from-cli) page, which already pins `--version 0.2.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)