### PR TITLE
docs(basecamp): rewrite atomic-swaps setup to the in-app Setup tab (0.4.3)

### DIFF
--- a/docs/basecamp/swap-eth-and-lez-tokens-in-logos-basecamp.md
+++ b/docs/basecamp/swap-eth-and-lez-tokens-in-logos-basecamp.md
@@ -17,7 +17,7 @@ sidebar_position: 3
 
 The atomic swap app is a Logos [Basecamp](../get-started/glossary.md#basecamp) app that trades tokens across two unrelated chains without an exchange, a bridge, or an escrow agent. This procedure takes you from a fresh Basecamp install to a completed swap against a live counterparty that Logos operates, ending with a receipt you can check on both chains' block explorers.
 
-You install this app from a [catalogue](../get-started/glossary.md#catalogue) URL rather than building it. There's no repository to clone, no Nix, and no local chain. One part still isn't as smooth: on the currently published version, creating your [LEZ](../get-started/glossary.md#lez) [account](../get-started/glossary.md#account) in [Step 2](#step-2-set-up-your-accounts) needs a command-line tool. That step says so plainly, and a release that removes the need is on the way.
+You install this app from a [catalogue](../get-started/glossary.md#catalogue) URL rather than building it. There's no repository to clone, no Nix, and no local chain. Version `0.4.3` also sets up both of your accounts inside the app: a guided **Setup** tab generates your Ethereum key, then creates, initialises, and funds your [LEZ](../get-started/glossary.md#lez) [account](../get-started/glossary.md#account) in [Step 2](#step-2-set-up-your-accounts). Nothing in this journey needs a command line.
 
 ## Networks and addresses
 
@@ -49,16 +49,14 @@ The time locks make the failure case safe. Each lock carries a deadline, and you
 
 - [Basecamp installed and running](./install-logos-basecamp.md).
 - Internet access.
-- An **Ethereum wallet** such as MetaMask, used in [Step 2](#step-2-set-up-your-accounts) to create a throwaway key.
-- A small amount of **Sepolia ETH**. The trade itself costs `0.00001` ETH, so roughly `0.01` Sepolia ETH covers it and the gas comfortably.
-    - You can obtain Sepolia ETH from any [public Sepolia faucet](https://ethereum.org/en/developers/docs/networks/).
-- **Rust and `cargo`**, installed from [rustup](https://rustup.rs).
+- A small amount of **Sepolia ETH**, sent to the throwaway Ethereum address the app generates for you in [Step 2](#step-2-set-up-your-accounts). The trade itself costs `0.00001` ETH, so roughly `0.01` Sepolia ETH covers it and the gas comfortably.
+    - You can obtain Sepolia ETH from any [public Sepolia faucet](https://ethereum.org/en/developers/docs/networks/). Most faucets just ask for the destination address, so you don't need a separate wallet app.
 :::
 
 ## What to expect
 
 - You can add a third-party catalogue to Basecamp and install an app from it.
-- You can set up a funded Ethereum key and an initialised, funded LEZ account, and point the app at both.
+- You can use the app's guided **Setup** tab to generate an Ethereum key and to create, initialise, and fund a LEZ account, with no command line and no hand-copied keys.
 - You can take a live offer and complete a real cross-chain swap on public test networks.
 - You can verify both legs of your swap independently on two block explorers.
 
@@ -84,7 +82,7 @@ Basecamp arrives with the official Logos catalogue configured, and it merges tha
 
 1. Go back to **Package Manager** and search for `swap`.
 
-    **Expected:** two packages from the new repository, `swap` and `swap_ui`, both shown as **ETH ↔ LEZ Atomic Swap** at version `0.3.3`.
+    **Expected:** two packages from the new repository, `swap` and `swap_ui`, both shown as **ETH ↔ LEZ Atomic Swap** at version `0.4.3`.
 
 1. Install `swap` first, then install `swap_ui`.
 
@@ -96,7 +94,9 @@ Basecamp arrives with the official Logos catalogue configured, and it merges tha
 
 1. Restart Basecamp, then open **ETH ↔ LEZ Atomic Swap** from the sidebar.
 
-    **Expected:** a row of six tabs across the top: **Market**, **Config**, **Maker**, **Taker**, **Refund**, and **History**. Along the top you also get live `ETH` and `LEZ` balances with a **Refresh** button, and a status line that settles on `Delivery connected` once the app finds a peer.
+    **Expected:** a row of seven tabs across the top: **Market**, **Config**, **Maker**, **Taker**, **Refund**, **History**, and **Setup**. Along the top you also get live `ETH` and `LEZ` balances with a **Refresh** button, and a status line that settles on `Delivery connected` once the app finds a peer.
+
+    On a fresh install, with nothing configured yet, the app opens on the **Setup** tab for you. That's the next step.
 
 :::info
 The catalogue is saved in your Basecamp settings and survives restarts. You add it once.
@@ -104,65 +104,57 @@ The catalogue is saved in your Basecamp settings and survives restarts. You add 
 
 ## Step 2: Set up your accounts
 
-A swap needs two identities: an Ethereum key to sign your Sepolia transactions, and an initialised LEZ account to receive your tokens. On `0.3.3` you create both outside the app, then paste them into the **Config** tab in [Step 3](#step-3-fill-in-the-config-tab).
+A swap needs two identities: an Ethereum key to sign your Sepolia transactions, and an initialised LEZ account to receive your tokens. Version `0.4.3` builds both for you in the **Setup** tab — no command line, and no copying a raw private key between apps. Every field the tab fills is an ordinary **Config** field underneath, so nothing here is hidden from you.
 
-:::warning
-This is the roughest part of the journey, and it's worth knowing why before you start. Version `0.3.3` has no in-app account setup, so you handle an Ethereum private key yourself and use a separate command-line tool for the LEZ side. Copying a raw private key between applications is a bad habit, and this app is in the process of removing the need for it. Until that lands, use a **brand-new key that holds nothing but Sepolia test funds**, and never paste in a key you also use on Ethereum mainnet.
-:::
-
-### Create a funded Ethereum key
-
-1. In an Ethereum wallet such as MetaMask, create a **new** account to use for this journey alone.
-
-1. Copy its address, and send Sepolia ETH to that address from a public faucet.
-
-1. Export the account's private key and keep it to hand for [Step 3](#step-3-fill-in-the-config-tab). In MetaMask this is under **Account details** → **Show private key**.
-
-**Expected:** a 64-character hex private key, and an address showing a non-zero Sepolia balance.
-
-### Create, initialise, and fund a LEZ account
-
-The LEZ side needs an account that exists, is initialised on-chain, and holds tokens. The LEZ wallet CLI does all three, and it's the only route on `0.3.3`. It's built from source with `cargo`, so this part does need a terminal.
-
-Follow [Run an LEZ wallet via the CLI](../lez/get-started/run-lez-wallet-via-cli.md) as far as the end of **Install the wallet and connect it to the testnet**. That builds the wallet and points it at `https://testnet.lez.logos.co`, the same sequencer this app uses.
-
-Then create a [public account](../get-started/glossary.md#public-account), initialise it on-chain, and fund it from the [Piñata](../get-started/glossary.md#piñata) faucet:
-
-```bash
-wallet account new public --label me
-wallet auth-transfer init --account-id Public/<ACCOUNT_ID>
-wallet pinata claim --to me
-```
-
-**Expected:** the first command prints both an account ID and a private key. **Record both.** The second initialises the account on-chain. The third credits `150` LEZ, and you can repeat it as often as you need.
+On a fresh install the app opens on the **Setup** tab automatically. You can also reach it any time from the **Setup** tab at the right-hand end of the tab row.
 
 :::info
-Don't skip the initialise command. An uninitialised LEZ account is the most confusing failure in this app, because it produces no error at all. The sequencer silently discards transactions that reference an account it has never seen initialised, so the swap simply stalls rather than failing. The wallet reports `Account is Uninitialized` until you initialise it.
+The Ethereum key the app generates is a fresh, throwaway key. Fund it with Sepolia test ETH only, and never treat it as a wallet for real funds.
 :::
 
-## Step 3: Fill in the Config tab
+1. Open the **Setup** tab.
 
-The **Config** tab holds every endpoint, address, and key the app uses, grouped under **Ethereum**, **LEZ**, and **Swap parameters**. Almost all of it is already correct. This step is a check rather than a data-entry exercise.
+    **Expected:** a page headed **Get set up** with three numbered cards — **1. Ethereum key**, **2. LEZ account**, and **3. Fund it**. Each card's border turns green as you complete it, and a **4. Done** card appears once funding finishes.
+
+1. Under **1. Ethereum key**, click **Generate new key**.
+
+    **Expected:** the card shows `done` and displays **Address:** followed by a new `0x…` address. The app writes the matching private key straight into **Config** for you; you never see or paste it.
+
+1. Send Sepolia ETH to that address from a public faucet.
+
+    This is the one part that has to happen outside the app, because only you can fund your Ethereum address. It's the LEZ side, not this one, that the app funds for you in the next two cards, so you can send the Sepolia ETH now or while the LEZ funding runs. You'll need it before you take an offer in [Step 4](#step-4-take-a-live-offer).
+
+    :::info
+    The card shows the address but has no copy button. To copy it exactly, open the **Config** tab and copy **Recipient Address** under **Ethereum**, which the app filled with the same address.
+    :::
+
+1. Under **2. LEZ account**, click **Create LEZ account**.
+
+    **Expected:** the card shows `done` and displays **Account:** followed by your new [account](../get-started/glossary.md#account) ID. Nothing is on-chain yet — creating the account is local, and the next card is what puts it on-chain.
+
+1. Under **3. Fund it**, click **Fund my account**.
+
+    **Expected:** the button changes to **Setting up…** and a status line appears with a live seconds counter. It initialises your account on-chain, then claims `150` LEZ from the [Piñata](../get-started/glossary.md#piñata) faucet — each phase needs a proof-of-work solve and an on-chain commit, and testnet blocks can be a minute or more apart, so the counter keeps moving to show it isn't stuck. When it finishes, the card shows `done`, the status reads **Funded and ready**, and a **4. Done** card appears with a **Go to Market** button.
+
+:::info
+The **Fund my account** button initialises the account for you, so you can't forget to. That matters because an uninitialised LEZ account is the most confusing failure in this app: the sequencer silently discards transactions that reference an account it has never seen initialised, so a swap simply stalls rather than failing. If a swap ever does nothing at all, re-running **Fund my account** re-checks the initialisation.
+:::
+
+## Step 3: Confirm your configuration
+
+The **Config** tab holds every endpoint, address, and key the app uses, grouped under **Ethereum**, **LEZ**, and **Swap parameters**. After the **Setup** tab, the key fields are already filled and the network values ship pre-filled, so this step is a check rather than a data-entry exercise. You can skip it and still complete a swap; it's here so you can see what **Setup** did and confirm nothing is off.
 
 1. Open the **Config** tab.
 
 1. Under **Ethereum**, confirm **RPC URL** is `wss://ethereum-sepolia-rpc.publicnode.com` and **HTLC Contract Address** is `0x351B0EA07739FA9F6769213927D7836a790A5FAF`.
 
-1. Still under **Ethereum**, paste the private key from [Step 2](#step-2-set-up-your-accounts) into **Private Key**, and the matching address into **Recipient Address**.
-
-    **Recipient Address** is where your bought tokens' counterpart settles, so it's the address belonging to that same key.
+1. Still under **Ethereum**, confirm **Private Key** and **Recipient Address** are populated. **Setup** filled both from the key it generated in [Step 2](#step-2-set-up-your-accounts). **Recipient Address** is where your bought tokens' counterpart settles, so it's the address belonging to that same key.
 
 1. Under **LEZ**, confirm **Sequencer URL** is `https://testnet.lez.logos.co` and **HTLC Program ID** is `27720b5b0345135d8e684eb172c27f5fb237548cc891a3ec889d0ed340504070`.
 
-1. Still under **LEZ**, paste the private key from [Step 2](#step-2-set-up-your-accounts) into **Signing Key**, and your account ID into **Taker Account ID**.
+1. Still under **LEZ**, confirm **Signing Key** is populated. **Setup** filled it from the LEZ account it created in [Step 2](#step-2-set-up-your-accounts).
 
-    Leave **Wallet Home** and **Wallet Account ID** empty. The app authenticates to the LEZ either with a signing key or with a wallet directory plus account ID, and the signing key is the route that works here. **Wallet Home**'s placeholder, `.scaffold/wallet`, is a path from the app's development setup that doesn't exist on a machine that installed from the catalogue.
-
-    **Taker Account ID** is the account that receives the maker's LEZ, and it's required whether or not you set anything else.
-
-    :::warning
-    The **Signing Key** must be **64 hex characters with no `0x` prefix**. The **Private Key** field above it accepts either form, so it's easy to assume this one does too. It doesn't: a `0x`-prefixed LEZ key passes the Config tab's validation and then fails at run time with `invalid LEZ signing key hex` when a swap starts.
-    :::
+    Leave **Wallet Home**, **Wallet Account ID**, and **Taker Account ID** empty. The app authenticates to the LEZ with the signing key, so the wallet fields aren't needed. **Taker Account ID** is an optional maker-side setting — a list of counterparties you'd allow to take your offers — and taking an offer doesn't need it. **Wallet Home**'s placeholder, `.scaffold/wallet`, is a path from the app's development setup that doesn't exist on a machine that installed from the catalogue.
 
 1. Leave **Swap parameters** alone.
 
@@ -254,7 +246,7 @@ Check **RPC URL** begins with `wss://` and not `https://`. The app opens a WebSo
 
 ### The swap does nothing and no error appears
 
-Your LEZ account is almost certainly uninitialised. The sequencer discards transactions for an account it has never seen initialised and returns no error, so the app has nothing to report. Check the account with the wallet CLI from [Step 2](#step-2-set-up-your-accounts). If it reports `Account is Uninitialized`, run the initialise step, then confirm the balance is genuinely positive before retrying.
+Your LEZ account is almost certainly uninitialised. The sequencer discards transactions for an account it has never seen initialised and returns no error, so the app has nothing to report. Open the **Setup** tab from [Step 2](#step-2-set-up-your-accounts) and click **Fund my account** again — it re-checks the on-chain initialisation and tops the balance back up. Confirm the balance is genuinely positive before retrying.
 
 ### The Taker tab reports `ETH lock rejected`
 
@@ -262,7 +254,7 @@ The maker refuses a lock that doesn't leave it enough time to respond, and the E
 
 ### There isn't enough LEZ in the account
 
-Claim from the Piñata faucet again with the wallet CLI from [Step 2](#step-2-set-up-your-accounts). Each claim credits a bounded amount, so repeat it until the balance covers what you need.
+Open the **Setup** tab from [Step 2](#step-2-set-up-your-accounts) and click **Fund my account** again. Each run claims `150` LEZ from the Piñata faucet, so repeat it until the balance covers what you need.
 
 ### A swap stopped halfway and the funds are still locked
 


### PR DESCRIPTION
Follow-up to #424 (merged as `cd311e0`). Closes/refs #428.

## Problem
The "Swap ETH and LEZ tokens in Logos Basecamp" journey still documented the **0.3.3** onboarding: create an ETH key in MetaMask, build the LEZ wallet CLI with Rust/`cargo`, run `wallet account new` / `auth-transfer init` / `pinata claim`, then hand-paste the raw keys into the **Config** tab. The shipped app now has a guided in-app **Setup** tab that does all of this.

## What changed
Single file: `docs/basecamp/swap-eth-and-lez-tokens-in-logos-basecamp.md`.

- **Step 2 "Set up your accounts"** — rewritten to the **Setup** tab flow: open Setup → **Generate new key** → **Create LEZ account** → **Fund my account** (initialises on-chain, then claims 150 LEZ from the Piñata faucet). Sending Sepolia ETH to the app-generated address is the only out-of-app action, since only the user can fund their ETH address.
- **Step 3** renamed **"Fill in the Config tab" → "Confirm your configuration"** — the Setup tab fills the key fields, so this is now a check, not data entry. Also corrects a stale claim: **Taker Account ID** is *not* required (it's an optional maker-side allowlist; the taker never reads it).
- **Prerequisites** — dropped Rust/`cargo` and the MetaMask key-creation step; kept the Sepolia ETH requirement (now sent to the generated address).
- **Version/tab strings** — `0.3.3` → `0.4.3`; "six tabs" → "seven tabs" with **Setup** appended; noted the app opens on **Setup** on a fresh install.
- **Troubleshooting** — the uninitialised-account and low-LEZ fixes now point at the Setup tab's **Fund my account** button instead of the wallet CLI.

Steps 4–6 (take an offer, read the receipt, send feedback) were already correct and are untouched. Install/catalogue URL was already the org catalogue (`raw.githubusercontent.com/logos-co/eth-lez-atomic-swaps/master/logos-repo.json`), not the stale substratestudios mirror — no change needed there.

## Verification
Setup flow verified against the app source (`swap-ui/src/qml/SetupView.qml`, `swap-ui/src/qml/AtomicSwapView.qml`, `swap-ui/src/swap_ui_plugin.cpp`): card/button labels, the seven-tab row with Setup at index 6, auto-navigation to Setup on incomplete config, the 150-LEZ funding target, and that `validateConfig` no longer requires `lez_taker_account_id`.

logos-docs has no build/lint CI, so the rendered markdown was re-read for broken links, stale version strings, and wrong tab names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)