### PR TITLE
chore: revise storage tutorials

### DIFF
--- a/docs/run-a-node/get-started/run-logos-node-blockchain-storage-delivery.md
+++ b/docs/run-a-node/get-started/run-logos-node-blockchain-storage-delivery.md
@@ -165,7 +165,7 @@ Download and install the three module packages from the configured module [catal
 
    ```sh
    lgpd download blockchain_module --version 0.2.2 --output /opt/logos-node/packages
-   lgpd download storage_module --version 2.1.0 --root-hash c9ad6299dd62be478dc89a589cb88ab5876bee11812ed3bcaf97ecadcac0b34e --output /opt/logos-node/packages
+   lgpd download storage_module --version 2.1.2 --root-hash c9ad6299dd62be478dc89a589cb88ab5876bee11812ed3bcaf97ecadcac0b34e --output /opt/logos-node/packages
    lgpd download delivery_module --version 0.2.0 --root-hash eb47c06575a6113f34a6d71e5e0b72d6d2db2ec7510b8be0ab9633b8385edd57 --output /opt/logos-node/packages
    ```
 

--- a/docs/storage/get-started/run-logos-storage-node.md
+++ b/docs/storage/get-started/run-logos-storage-node.md
@@ -215,7 +215,7 @@ We will now download the Logos book, [Farewell to Westphalia](https://logos.co/b
     ```sh
     CID="zDvZRwzkzrrYB6sS1rRpRLt4gBhc1pWoyTSjkfszfmj1seaYYLCZ"
     logoscore call storage_module downloadToUrl "$CID" "$(pwd)/farewell-to-westphalia.pdf" false 65536
-    ``
+    ```
 
     :::tip
     The `local` flag reads only from locally cached data when set to `true`; `false` fetches from the network.
@@ -224,7 +224,7 @@ We will now download the Logos book, [Farewell to Westphalia](https://logos.co/b
 1.  Wait for a while for the file to download. After a few seconds, check if the downloaded file is present at the destination path. You should try to open the pdf, and it should contain the whole book.
 
     ```sh
-    sha1sum "$(pwd)/farewell-to-westphalia.pdf"
+    shasum "$(pwd)/farewell-to-westphalia.pdf"
     # 2c6b4dc8e8e4dae336b87b9922c38f3c94217872  farewell-to-westphalia.pdf
     ```
 

--- a/docs/storage/get-started/run-logos-storage-node.md
+++ b/docs/storage/get-started/run-logos-storage-node.md
@@ -214,7 +214,7 @@ We will now download the Logos book, [Farewell to Westphalia](https://logos.co/b
 
     ```sh
     CID="zDvZRwzkzrrYB6sS1rRpRLt4gBhc1pWoyTSjkfszfmj1seaYYLCZ"
-    logoscore call storage_module downloadToUrl "$CID" "$(pwd)/farewell-to-westphalia.pdf" true 65536
+    logoscore call storage_module downloadToUrl "$CID" "$(pwd)/farewell-to-westphalia.pdf" false 65536
     ``
 
     :::tip

--- a/docs/storage/get-started/run-logos-storage-node.md
+++ b/docs/storage/get-started/run-logos-storage-node.md
@@ -23,17 +23,23 @@ This procedure covers how to build and run the [Logos Storage Module](https://gi
 
 - A supported OS:
     - Linux
+    - Mac OS (should work, but not tested)
 - `jq` on your `PATH`.
     - To verify, run: `jq --version`
-- **Nix** with flakes enabled. Install from [nixos.org](https://nixos.org/download.html), then enable flakes:
+- The Logos tool suite:
+    - [`logoscore`](https://github.com/logos-co/logos-logoscore-cli/releases/tag/0.2.2) (the Logos runtime);
+    - [`lgpd`](https://github.com/logos-co/logos-package-downloader/releases/tag/0.2.1) (the Logos package downloader);
+    - [`lgpm`](https://github.com/logos-co/logos-package-manager/releases/tag/0.2.1) (the Logos package manager).
 
-   ```bash
-   mkdir -p ~/.config/nix
-   echo 'experimental-features = nix-command flakes' >> ~/.config/nix/nix.conf
-   ```
-- [`logoscore`](https://github.com/logos-co/logos-logoscore-cli/releases/tag/0.2.2), and [`lgpm`](https://github.com/logos-co/logos-package-manager/releases/tag/0.2.1) installed. To install these tools, use the `install-node-tools.sh` helper script:
+  You can obtain them by running:
 
     ```bash
+    # Export those first or the script will fetch the latest version, which might not
+    # work with this tutorial
+    export LGPM_TAG=0.2.1
+    export LGPD_TAG=0.2.1
+    export LOGOSCORE_TAG=0.2.2
+
     curl -fsSL https://raw.githubusercontent.com/logos-co/logos-docs/main/resources/scripts/install-node-tools.sh | sh
     export PATH="$PWD/bin:$PATH"
     ```
@@ -41,41 +47,44 @@ This procedure covers how to build and run the [Logos Storage Module](https://gi
 
 ## What to expect
 
-- You can connect a [Logos Storage](../../get-started/glossary.md#logos-storage) node to the testnet and have it listed among the bootstrap peers.
-- You can publish a file to the network and retrieve a content address to share with other nodes.
-- You can download the file back from the network and confirm it lands on disk.
+In this tutorial, you will:
 
-## Build and install the storage module
+- Connect a [Logos Storage](../../get-started/glossary.md#logos-storage) node to the testnet.
+- Publish a file to the network.
+- Download an existing file - the Logos book, [Farewell to Westphalia](https://logos.co/book) - from the Logos storage network.
 
-1.  Build the module package with Nix:
+## Download and install the storage module
+
+1.  Download the storage module:
 
     ```sh
-    nix build 'github:logos-co/logos-storage-module/v2.1.0#lgx-portable' -o storage-lgx
+    mkdir -p storage-lgx
+    lgpd download storage_module --version 2.1.2 -o storage-lgx
     ```
 
-    - This produces a `.lgx` package in `./storage-lgx/`.
+    This should download an `lgx` file in the `storage-lgx` folder.
 
-    :::info
-    The initial Nix build takes 15–20 minutes on first run. Subsequent builds use the Nix cache and complete in seconds.
-    :::
-
-1.  Install the package into a local modules directory using `lgpm`. The package is a local build and is unsigned, so pass `--allow-unsigned`:
+1.  Install the package using `lgpm`.
 
     ```sh
     mkdir -p modules
-    lgpm --modules-dir ./modules --allow-unsigned install --file storage-lgx/*.lgx
+    lgpm --modules-dir ./modules install --file storage-lgx/*.lgx
     ```
 
 1.  Confirm the module landed:
 
     ```sh
     lgpm --modules-dir ./modules list
-    # storage_module appears in the listing
+    Found 1 installed module(s):
+
+    NAME                           VERSION         TYPE       CATEGORY
+    ----------------------------------------------------------------------
+    storage_module                 (v)           core       protocol
     ```
 
 ## Start the daemon and load the storage module
 
-Run `logoscore` with the modules directory, then load and initialise the storage module against the testnet config.
+Run `logoscore` with the modules directory, then load and initialise the storage module.
 
 Several module calls in this procedure are **asynchronous**: the call returns `"result":true` as soon as the command is accepted, and the real outcome is delivered later as an event (`storageStart`, `storageUploadDone`, `storageDownloadDone`, `storageRemoveDone`, `storageDownloadManifestDone`). These events are emitted to event subscribers (such as the Storage UI); the `logoscore call` client does not subscribe to them, so they do **not** appear in `logs.txt`. Each step below instead waits briefly and confirms the outcome with a follow-up query (for example `manifests` or `exists`).
 
@@ -122,43 +131,32 @@ Several module calls in this procedure are **asynchronous**: the call returns `"
 
     - To see every method the module exposes (the same methods you can `call`), run `logoscore module-info storage_module`.
 
-1.  Create the storage config. Use **absolute** paths: in daemon mode the module runs as its own process, whose working directory is not the one you are typing in, so relative paths resolve to the wrong place. Replace `your-public-IP` by your public external IP. The `$(pwd)` in the heredoc takes care of it:
+1.  Create a minimal storage config. Use **absolute** paths: in daemon mode the module runs as its own process, whose working directory is not the one you are typing in, so relative paths resolve to the wrong place. The `$(pwd)` in the heredoc takes care of it:
 
     ```sh
     mkdir -p "$(pwd)/storage-data"
     cat > config.json <<EOF
     {
         "data-dir": "$(pwd)/storage-data",
-        "log-level": "INFO",
-        "log-file": "$(pwd)/storage-data/storage.log",
-        "listen-ip": "0.0.0.0",
-        "listen-port": 8091,
-        "disc-port": 8090,
-        "network": "logos.test",
-        "nat": "extip:<your-public-IP>"
+        "log-file": "$(pwd)/storage-data/storage.log"
     }
     EOF
     ```
-
-    - With `"nat": "extip:<your-public-IP>"` the node announces the machine's own IP as-is. If it is reachable from other peers over Internet (with ports forwarded for example), the node will be able to upload and download from other peers. Otherwise, it can only download from the network but other peers will not be able to download from this node. To know more about node reachable state: see [Connectivity](../concepts/connectivity.md).
 
     - `config.json` includes the following fields:
 
     | Field | Purpose |
     |-------|---------|
     | `data-dir` | Storage repository path (absolute) |
-    | `log-level` | Log verbosity |
     | `log-file` | Node log destination (absolute) |
-    | `listen-ip` | Local TCP bind address |
-    | `listen-port` | Public TCP libp2p port |
-    | `disc-port` | Public UDP discovery port |
-    | `network` | Storage network preset |
-    | `nat` | Public IP advertisement mode — see [Connectivity](../concepts/connectivity.md) |
 
-    - Every omitted key keeps its default: the node joins the `logos.test` network preset (which provides the testnet bootstrap settings), binds discovery to the default UDP port `8090`, and picks a random TCP `listen-port`.
-    - For a public, reachable node, set fixed `listen-port` (TCP) and `disc-port` (UDP) values: see [Connectivity](../concepts/connectivity.md).
+    - The default settings for Logos storage should be enough to get your node properly connected onto the Logos testnet. In case you want more control over port allocation, or want to learn more about how Logos storage operates, see [Connectivity](../concepts/connectivity.md).
 
-1.  Initialise the storage module with the testnet configuration. `init` is synchronous and returns `true` on success (the `@config.json` syntax loads the file's contents as the argument):
+    :::tip
+    If you plan on running a node for longer, consider helping the network by setting up port mapping on your router (see [Connectivity](../concepts/connectivity.md) for details).
+    :::
+
+1.  Initialise the storage module. `init` is synchronous and returns `true` on success (the `@config.json` syntax loads the file's contents as the argument):
 
     ```sh
     logoscore call storage_module init @config.json
@@ -171,15 +169,18 @@ Several module calls in this procedure are **asynchronous**: the call returns `"
     # Wait few seconds to start
     ```
 
-1.  Inspect the running node with `debug`. It returns the node's identity: its `id` ([peer ID](../../get-started/glossary.md#peer-id)) and its `spr`, the signed record other nodes use to connect to you (see [Connectivity](../concepts/connectivity.md)):
+1.  Inspect the running node with `debug`. It returns a lot of information about the node, including its `id` ([peer ID](../../get-started/glossary.md#peer-id)) and its `spr`, the signed record other nodes use to connect to you (see [Connectivity](../concepts/connectivity.md)):
 
     ```sh
-    logoscore call storage_module debug
+    logoscore call storage_module debug | jq .result.value.id
+    # "16Uiu2HAmMA4NuQoCHz9p7jUskVjDd8WncwG3p6qBNnhnftUE5Q9C" # Your peer ID
+    logoscore call storage_module debug | jq .result.value.spr
+    # "spr:CiUIAhIhA35P5KZosVyfWTfIHBVtC_PtI ... H9gX-vA" # Your SPR
     ```
 
-## Publish and download a file
+## Publish a file
 
-Once the node is running and connected to the testnet, publish a file and verify the round-trip.
+We will now publish a file to the Logos storage network. We create a simple file just for this tutorial, but you could publish any file you'd like.
 
 1.  Create a file to publish:
 
@@ -205,22 +206,26 @@ Once the node is running and connected to the testnet, publish a file and verify
        | jq -er '.result.value[0].cid' > cid.txt
     ```
 
-1.  Download the file back from local storage with `downloadToUrl`. It takes the CID, an **absolute** destination path, a `local` flag, and a chunk size in bytes. With `local` set to `true`, the download reads the blocks straight back out of this node's own repository. Like `uploadUrl` it runs in the background and completes with a `storageDownloadDone` event:
+## Download Farewell to Westphalia
+
+We will now download the Logos book, [Farewell to Westphalia](https://logos.co/book), from the Logos storage network.
+
+1. We will use `downloadToUrl` to download the file from the network and place it into your local disk. It takes the CID, an **absolute** destination path, a `local` flag, and a chunk size in bytes. We set `local` to `false` as this file is not currently available in your node. Like `uploadUrl` it runs in the background and completes with a `storageDownloadDone` event:
 
     ```sh
-    logoscore call storage_module downloadToUrl "$(cat cid.txt)" "$(pwd)/hello-destination.txt" true 65536
-    ```
+    CID="zDvZRwzkzrrYB6sS1rRpRLt4gBhc1pWoyTSjkfszfmj1seaYYLCZ"
+    logoscore call storage_module downloadToUrl "$CID" "$(pwd)/farewell-to-westphalia.pdf" true 65536
+    ``
 
-    - The `local` flag reads only from locally cached data when set to `true`; `false` fetches from the network.
+    :::tip
+    The `local` flag reads only from locally cached data when set to `true`; `false` fetches from the network.
+    :::
 
-1.  Confirm the downloaded file is present at the destination path and matches the original. You can also check the content is in local storage by CID:
+1.  Wait for a while for the file to download. After a few seconds, check if the downloaded file is present at the destination path. You should try to open the pdf, and it should contain the whole book.
 
     ```sh
-    # Confirm the download is a byte-for-byte copy of the original (both files are static):
-    diff "$(pwd)/hello.txt" "$(pwd)/hello-destination.txt" && echo "match"
-    # And confirm the content is in local storage by CID:
-    logoscore call storage_module exists "$(cat cid.txt)"
-    # returns true
+    sha1sum "$(pwd)/farewell-to-westphalia.pdf"
+    # 2c6b4dc8e8e4dae336b87b9922c38f3c94217872  farewell-to-westphalia.pdf
     ```
 
 ## Remove content and shut everything down
@@ -230,7 +235,10 @@ To clear your local storage, destroy the storage node, and stop the daemon, foll
 1.  Remove content from local storage by its CID. `remove` returns immediately; the outcome arrives as a `storageRemoveDone` event:
 
     ```sh
+    # Deletes the first file we uploaded.
     logoscore call storage_module remove "$(cat cid.txt)"
+    # Deletes the Farewell to Westphalia book.
+    logoscore call storage_module remove "zDvZRwzkzrrYB6sS1rRpRLt4gBhc1pWoyTSjkfszfmj1seaYYLCZ"
     ```
 
 1.  Confirm the content is gone:
@@ -238,6 +246,7 @@ To clear your local storage, destroy the storage node, and stop the daemon, foll
     ```sh
     # Wait a second for the removal to complete first
     logoscore call storage_module exists "$(cat cid.txt)" | jq '.result.value'
+    logoscore call storage_module exists "zDvZRwzkzrrYB6sS1rRpRLt4gBhc1pWoyTSjkfszfmj1seaYYLCZ" | jq '.result.value'
     # false
     ```
 

--- a/docs/storage/get-started/run-mix-network-of-storage-nodes.md
+++ b/docs/storage/get-started/run-mix-network-of-storage-nodes.md
@@ -24,22 +24,28 @@ This procedure stands up a small local [Mix](../concepts/mix.md) network using `
 
 - A supported OS:
     - Linux
-    - macOS
+    - Mac OS (should work, but not tested)
 - `jq` on your `PATH`.
     - To verify, run: `jq --version`
-- **Nix** with flakes enabled. Install from [nixos.org](https://nixos.org/download.html), then enable flakes:
+- The Logos tool suite:
+    - [`logoscore`](https://github.com/logos-co/logos-logoscore-cli/releases/tag/0.2.2) (the Logos runtime);
+    - [`lgpd`](https://github.com/logos-co/logos-package-downloader/releases/tag/0.2.1) (the Logos package downloader);
+    - [`lgpm`](https://github.com/logos-co/logos-package-manager/releases/tag/0.2.1) (the Logos package manager).
 
-   ```bash
-   mkdir -p ~/.config/nix
-   echo 'experimental-features = nix-command flakes' >> ~/.config/nix/nix.conf
-   ```
-- [`logoscore`](https://github.com/logos-co/logos-logoscore-cli/releases/tag/0.2.2), and [`lgpm`](https://github.com/logos-co/logos-package-manager/releases/tag/0.2.1) installed. To install these tools, use the `install-node-tools.sh` helper script:
+  You can obtain them by running:
 
     ```bash
+    # Export those first or the script will fetch the latest version, which might not
+    # work with this tutorial
+    export LGPM_TAG=0.2.1
+    export LGPD_TAG=0.2.1
+    export LOGOSCORE_TAG=0.2.2
+
     curl -fsSL https://raw.githubusercontent.com/logos-co/logos-docs/main/resources/scripts/install-node-tools.sh | sh
     export PATH="$PWD/bin:$PATH"
     ```
 :::
+
 
 ## What to expect
 
@@ -47,32 +53,31 @@ This procedure stands up a small local [Mix](../concepts/mix.md) network using `
 - You can set up a private Mix network and configure storage nodes to anonymize their lookups through it.
 - You can exchange a file between two storage nodes and verify the content lookup was tunnelled over Mix.
 
-## Build and install the storage module
-
-1.  Build the module package with Nix:
+1.  Download the storage module:
 
     ```sh
-    nix build 'github:logos-co/logos-storage-module/v2.1.0#lgx-portable' -o storage-lgx
+    mkdir -p storage-lgx
+    lgpd download storage_module --version 2.1.2 -o storage-lgx
     ```
 
-    - This produces a `logos-storage_module-module-lib.lgx` package in `./storage-lgx/`.
+    This should download an `lgx` file in the `storage-lgx` folder.
 
-    :::info
-    The initial Nix build takes 15–20 minutes on first run. Subsequent builds use the Nix cache and complete in seconds. Use the `#lgx-portable` output: it declares the standard platform variant (e.g. `linux-amd64`) that the release build of `lgpm` accepts.
-    :::
-
-1.  Install the package into a local modules directory using `lgpm`. The package is a local build and is unsigned, so pass `--allow-unsigned`. All six daemons share this one modules directory:
+1.  Install the package using `lgpm`.
 
     ```sh
     mkdir -p modules
-    lgpm --modules-dir ./modules --allow-unsigned install --file storage-lgx/*.lgx
+    lgpm --modules-dir ./modules install --file storage-lgx/*.lgx
     ```
 
 1.  Confirm the module landed:
 
     ```sh
     lgpm --modules-dir ./modules list
-    # storage_module appears in the listing
+    Found 1 installed module(s):
+
+    NAME                           VERSION         TYPE       CATEGORY
+    ----------------------------------------------------------------------
+    storage_module                 (v)           core       protocol
     ```
 
 ## Launch the bootstrap Mix node (node 1)
@@ -88,6 +93,7 @@ The first node is the bootstrap node: the other nodes use it to join the Mix net
       "log-level": "DEBUG",
       "data-dir": "$(pwd)/storage-data/node-1",
       "log-file": "$(pwd)/storage-data/node-1/storage.log",
+      "nat": "extip:127.0.0.1",
       "disc-port": 9091,
       "listen-port": 8081,
       "mix-enabled": true,
@@ -134,6 +140,7 @@ Nodes 2, 3 and 4 are identical to node 1, except that they join through node 1's
       "log-level": "DEBUG",
       "data-dir": "$(pwd)/storage-data/node-$id",
       "log-file": "$(pwd)/storage-data/node-$id/storage.log",
+      "nat": "extip:127.0.0.1",
       "disc-port": $((9090 + id)),
       "listen-port": $((8080 + id)),
       "mix-enabled": true,
@@ -167,9 +174,15 @@ Nodes 2, 3 and 4 are identical to node 1, except that they join through node 1's
 
     ```sh
     for id in 1 2 3 4; do
-      logoscore --config-dir=./logoscore-$id call storage_module debug \
-        | jq -e '(.result.value.id // "") != "" and (.result.value.spr // "") != ""'
+      started_up=$(logoscore --config-dir=./logoscore-$id call storage_module debug \
+        | jq -e '(.result.value.id // "") != "" and (.result.value.spr // "") != ""')
+      if [ "$started_up" = "true" ]; then
+        echo "Node $id is up"
+      else
+        echo "Node $id is down"
+      fi
     done
+    # You should see "Node X is up" for all nodes from 1 to 4
     ```
 
 ## Build the Mix relay pool
@@ -227,6 +240,7 @@ The four nodes so far are the Mix relays. Now add the storage nodes that actuall
       "log-file": "$(pwd)/storage-data/node-$id/storage.log",
       "disc-port": $((9090 + id)),
       "listen-port": $((8080 + id)),
+      "nat": "extip:127.0.0.1",
       "mix-enabled": true,
       "bootstrap-node": ["$BOOTSTRAP"],
       "dht-mix-proxy": $PROXIES,
@@ -318,6 +332,6 @@ Node 5 seeds a file, and node 6 downloads it with `local=false` to force a netwo
 1.  Confirm the daemons have stopped:
 
     ```sh
-    logoscore --config-dir=./logoscore-1 status
-    # reports "status":"not_running"
+    ps aux | grep logoscore | grep -v 'grep' | wc -l
+    # Should print "0"
     ```

--- a/docs/storage/get-started/run-mix-network-of-storage-nodes.md
+++ b/docs/storage/get-started/run-mix-network-of-storage-nodes.md
@@ -53,6 +53,8 @@ This procedure stands up a small local [Mix](../concepts/mix.md) network using `
 - You can set up a private Mix network and configure storage nodes to anonymize their lookups through it.
 - You can exchange a file between two storage nodes and verify the content lookup was tunnelled over Mix.
 
+## Download and install the storage module
+
 1.  Download the storage module:
 
     ```sh

--- a/docs/storage/get-started/set-up-and-use-logos-storage-ui.md
+++ b/docs/storage/get-started/set-up-and-use-logos-storage-ui.md
@@ -17,11 +17,6 @@ sidebar_position: 2
 
 The [Logos Storage](../../get-started/glossary.md#logos-storage) UI is a file-sharing application built on top of the [Logos Storage Module](https://github.com/logos-co/logos-storage-module). This guide covers running the application (through Logos [Basecamp](../../get-started/glossary.md#basecamp) or by building it with Nix), configuring your node through the onboarding wizard, and using the UI to share, download, and delete files. It is intended for node operators running the application on Linux or macOS.
 
-:::info[Prerequisites]
-
-- A router where you can configure port forwarding or that supports UPnP/NAT-PMP ready (see [Connectivity](../concepts/connectivity.md)).
-:::
-
 ## What to expect
 
 - You can build and run a standalone Logos Storage UI application using a single `nix build` command.
@@ -146,70 +141,6 @@ This guide follows the `Guided` setup.
 
    ![NAT status](../assets/set-up-and-use-logos-storage-ui/storage-ui-nat.png)
 
-:::warning 
-
-The latest Logos Storage Module (v2.1.0) relies on AutoNAT servers, which are not deployed on the `logos.test` network yet. NAT detection will not work until they are.
-
-In the meantime, you can point the node at other AutoNAT servers with a manual configuration:
-
-1. Bootstrap nodes: 
-
-```json
-[
-  "spr:CiUIAhIhA_30VxBSXq0xCjoMIlFKlnY7gBEQzHv0pRY5kHP17-pTEgIDARpICicAJQgCEiED_fRXEFJerTEKOgwiUUqWdjuAERDMe_SlFjmQc_Xv6lMQrJLE0wYaCgoIBM-a0SUGH5AaCwoJBM-a0SWRAh-aKkYwRAIgHGe5zrUfxBfg0bY-rf0WOaYkci1mvYnwmgMKeXRVo68CIHjJUGqlj5jwNklm_BuIdz5_kHpLYH4tfiADtZx3Xmnu",
-  "spr:CiUIAhIhAo61xuA0H8l-DQs4pjcsXRgIK_VrDlW9br-ad6-EAUKTEgIDARpICicAJQgCEiECjrXG4DQfyX4NCzimNyxdGAgr9WsOVb1uv5p3r4QBQpMQrJLE0wYaCgoIBEDicIcGH5AaCwoJBEDicIeRAh-aKkcwRQIhAIpb9JvG6OiphjL9gb1awcrGX8f-_j_qRcYkce5U6moLAiBjBF_uAtD5G6m_E_-TVHA-yV0klnYmrtCeyzm18KE9DA",
-  "spr:CiUIAhIhAlvt_ed7o68o2EjRMAOLxOaAjhfs4Xo1mSMj4zFmGjqJEgIDARpICicAJQgCEiECW-3953ujryjYSNEwA4vE5oCOF-zhejWZIyPjMWYaOokQrJLE0wYaCgoIBIZ6WPAGH5AaCwoJBIZ6WPCRAh-aKkcwRQIhAPR-rNdpKYHhVb-jW7rEFMvlILBgWn9TTCAPOhCxCSf9AiAa4yqBS1U-a1BfYKzFCQ86wh2LLTxtwLgXKekMmuHxsg",
-  "spr:CiUIAhIhAskyX6nTawF8y_IBEFWYiRNnjQDl8zpO78ImQpb5cXOuEgIDARpICicAJQgCEiECyTJfqdNrAXzL8gEQVZiJE2eNAOXzOk7vwiZClvlxc64QrJLE0wYaCgoIBIbR-fEGH5AaCwoJBIbR-fGRAh-aKkYwRAIgdbClsN6hpvfQRFopGJPN9-1P6fmrbv6sN0LNwSDs8xICIG_NXwQVb8IiGB5qMuREF6p-SjCWSKTFllWZFBmJHYmW"
-]
-```
-
-2. Mix relay pool:
-
-```json
-{
-  "version": 1,
-  "relays": [
-    {
-      "peerId": "16Uiu2HAmVkKbPiweAgwiqjWkhptDUApzEM2w7jEjpRWB3zpQe9ZU",
-      "multiAddr": "/ip4/207.154.209.37/tcp/8080",
-      "mixPubKey": "2922d84ffd5a2d0dc8206034390ec38972a64402188c265b92a2045d0559775a",
-      "libp2pPubKey": "03fdf45710525ead310a3a0c22514a96763b801110cc7bf4a516399073f5efea53"
-    },
-    {
-      "peerId": "16Uiu2HAm52kdvfTWTrkGhkvGQX8dp8FfRcaPc6UgTzLFHsSLVQCi",
-      "multiAddr": "/ip4/64.226.112.135/tcp/8080",
-      "mixPubKey": "d91c44f0aebb26a2d78f83d31c805ce478a86c7b35d9b44e10a8ae6f6c30ba00",
-      "libp2pPubKey": "028eb5c6e0341fc97e0d0b38a6372c5d18082bf56b0e55bd6ebf9a77af84014293"
-    },
-    {
-      "peerId": "16Uiu2HAm1cXZXgyw47PM7xL1FFiNVQuntihVevNFK5Fy18uZU62c",
-      "multiAddr": "/ip4/134.122.88.240/tcp/8080",
-      "mixPubKey": "7eccd26d9decc8c8f236788313f2d76247614a005ff85808b0e6b473e435514a",
-      "libp2pPubKey": "025bedfde77ba3af28d848d130038bc4e6808e17ece17a35992323e331661a3a89"
-    },
-    {
-      "peerId": "16Uiu2HAm8y4UgDx9L5FVBPPgpoA36sdydWkewuLVgM4rnvnMtg1T",
-      "multiAddr": "/ip4/134.209.249.241/tcp/8080",
-      "mixPubKey": "fdb59c1dc2eb066f697b69d58866579dfb50586b161e8c604becfe177c8eb147",
-      "libp2pPubKey": "02c9325fa9d36b017ccbf2011055988913678d00e5f33a4eefc2264296f97173ae"
-    }
-  ]
-}
-```
-
-3. DHT mix proxies: 
-
-```json
-[
-  "spr:CiUIAhIhA_30VxBSXq0xCjoMIlFKlnY7gBEQzHv0pRY5kHP17-pTEgIDARo7CicAJQgCEiED_fRXEFJerTEKOgwiUUqWdjuAERDMe_SlFjmQc_Xv6lMQl4nE0wYaCgoIBM-a0SUGH5AqRjBEAiAqH3RfY85YEUtyqBcFzGvDdQ8vV3g6teXDzocPeCWWKgIgGHFpJyc2-wxEaDQ5a5kIKgNOKxXqtF35dCfDQTKvgjg",
-  "spr:CiUIAhIhAo61xuA0H8l-DQs4pjcsXRgIK_VrDlW9br-ad6-EAUKTEgIDARo7CicAJQgCEiECjrXG4DQfyX4NCzimNyxdGAgr9WsOVb1uv5p3r4QBQpMQ0ZHE0wYaCgoIBEDicIcGH5AqRjBEAiAUDfpZJRvZ2QjNHZV3fRQ3Hz4NaMlf-reFir93l9JJJQIgYXzXn0Kuw1I5H4G9M2hrV0B7ufspkiTySJEXqbjc2TI",
-  "spr:CiUIAhIhAlvt_ed7o68o2EjRMAOLxOaAjhfs4Xo1mSMj4zFmGjqJEgIDARo7CicAJQgCEiECW-3953ujryjYSNEwA4vE5oCOF-zhejWZIyPjMWYaOokQ0ZHE0wYaCgoIBIZ6WPAGH5AqRzBFAiEA0CDBW5lpQ1IHZvh17-0aHS0YBrLVRrYlHDNVNnzrxiACIHrxDmdsrDKM2gFnU67yGXq0ukUMLMyVoUv7NmMbAh1V",
-  "spr:CiUIAhIhAskyX6nTawF8y_IBEFWYiRNnjQDl8zpO78ImQpb5cXOuEgIDARo7CicAJQgCEiECyTJfqdNrAXzL8gEQVZiJE2eNAOXzOk7vwiZClvlxc64Q0pHE0wYaCgoIBIbR-fEGH5AqRzBFAiEAovgkG6R4aF6vdwB2t8tI8S0BAHey8O6AgZr-RpfITxUCIDEV4e4P_Vhf8h_gHi4AyE5T-gDJWvsMnPhbGFITcOQm"
-]
-```
-
-:::
-
 ### Configuration
 
 After onboarding, the settings are saved to a file whose location depends on the OS. If you are running the UI inside the Basecamp application:
@@ -260,7 +191,7 @@ When the file is downloaded, the download icon will turn green indicating that t
 
 The **Mix** switch in the **Node** panel controls private queries. When enabled, the node forwards its content lookups over the Logos mix network, which makes them much harder to trace back to you. See [Mix](../concepts/mix.md) for how it works.
 
-- The switch is on by default when your configuration includes the Mix options.
+- The switch is on by default when your configuration includes the Mix options (which, by default, it does).
 - Private queries can be slower and may fail more often than direct ones. When looking up content that is not sensitive, you can toggle the switch off — observers will then be able to link you to your queries.
 
 :::warning

--- a/resources/scripts/install-node-tools.sh
+++ b/resources/scripts/install-node-tools.sh
@@ -7,9 +7,9 @@
 set -eu
 
 # Pinned tool releases.
-LOGOSCORE_TAG=0.2.2
-LGPD_TAG=0.2.1
-LGPM_TAG=0.2.1
+LOGOSCORE_TAG=${LOGOSCORE_TAG:-0.2.2}
+LGPD_TAG=${LGPD_TAG:-0.2.1}
+LGPM_TAG=${LGPM_TAG:-0.2.1}
 
 os=$(uname -s | tr '[:upper:]' '[:lower:]')
 if [ "$os" = darwin ]; then os=macos; fi


### PR DESCRIPTION
This PR revises the storage tutorials so that:

1. headless tutorials use lgpd instead of nix builds;
2. the storage node tutorial include the download of public files available on the testnet;
3. NAT configuration reflects our more modern NAT traversal machinery;
4. the UI tutorial removes the Mix configs (those are baked into the UI binary as of https://github.com/logos-co/logos-storage-ui/pull/84).

In particular, I've strived to keep configurations as compact as possible, and avoid useless steps. I kept the nix build and the standalone app in the UI tutorial for now, as it's provided in addition to the simpler, basecamp-based option.